### PR TITLE
feat(arc-278): replace query param object for spaces with primitives

### DIFF
--- a/src/modules/spaces/controllers/spaces.controller.ts
+++ b/src/modules/spaces/controllers/spaces.controller.ts
@@ -1,7 +1,6 @@
 import { Controller, Get, Logger, Param, ParseUUIDPipe, Query } from '@nestjs/common';
 import { IPagination } from '@studiohyperdrive/pagination';
 
-import { SpacesQueryDto } from '../dto/spaces.dto';
 import { SpacesService } from '../services/spaces.service';
 import { Space } from '../types';
 
@@ -12,8 +11,16 @@ export class SpacesController {
 	constructor(private spacesService: SpacesService) {}
 
 	@Get()
-	public async getSpaces(@Query() query: SpacesQueryDto): Promise<IPagination<Space>> {
-		const spaces = await this.spacesService.findAll(query);
+	public async getSpaces(
+		@Query('query') query: string,
+		@Query('size') size: string,
+		@Query('page') page: string
+	): Promise<IPagination<Space>> {
+		const spaces = await this.spacesService.findAll({
+			query: query,
+			size: size ? parseInt(size) : undefined,
+			page: page ? parseInt(page) : undefined,
+		});
 		return spaces;
 	}
 

--- a/src/modules/spaces/services/spaces.service.ts
+++ b/src/modules/spaces/services/spaces.service.ts
@@ -76,9 +76,9 @@ export class SpacesService {
 		const { query, page, size } = inputQuery;
 		const { offset, limit } = this.convertPagination(page, size);
 		const spacesResponse = await this.dataService.execute(FIND_SPACES, {
-			query,
-			offset,
-			limit,
+			query: query || '%%',
+			offset: offset || 0,
+			limit: limit || 20,
 		});
 
 		return Pagination<Space>({


### PR DESCRIPTION
Since it is a get request all @Query params will be strings. so i think we still need to parse them before using them.
I'll test it out with an object once i add the swagger docs to nestjs.

example of the request:
![image](https://user-images.githubusercontent.com/1710840/153018120-977a35b4-02f2-43a8-b270-78640aa4f60d.png)

