### PR TITLE
feat(swagger): enable swagger docs for non production servers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@nestjs/core": "8.2.3",
         "@nestjs/platform-express": "8.2.3",
         "@nestjs/schedule": "1.0.2",
+        "@nestjs/swagger": "5.2.0",
         "@studiohyperdrive/pagination": "1.0.0",
         "class-transformer": "0.5.1",
         "class-validator": "0.13.2",
@@ -32,6 +33,7 @@
         "rimraf": "3.0.2",
         "rxjs": "7.4.0",
         "saml2-js": "3.0.1",
+        "swagger-ui-express": "4.3.0",
         "xml-js": "1.6.11"
       },
       "devDependencies": {
@@ -2193,6 +2195,50 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-5.2.0.tgz",
+      "integrity": "sha512-wcW2KCe7irwBw0WKsb03uFk4gnjqNcAcJxXGZxi6ljFiDgyLrQtx5MpE95o703tnn4V/hZR8MqMNFOXuup7Pqw==",
+      "dependencies": {
+        "@nestjs/mapped-types": "1.0.1",
+        "lodash": "4.17.21",
+        "path-to-regexp": "3.2.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0",
+        "@nestjs/core": "^8.0.0",
+        "fastify-swagger": "*",
+        "reflect-metadata": "^0.1.12",
+        "swagger-ui-express": "*"
+      },
+      "peerDependenciesMeta": {
+        "fastify-swagger": {
+          "optional": true
+        },
+        "swagger-ui-express": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/swagger/node_modules/@nestjs/mapped-types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-1.0.1.tgz",
+      "integrity": "sha512-NFvofzSinp00j5rzUd4tf+xi9od6383iY0JP7o0Bnu1fuItAUkWBgc4EKuIQ3D+c2QI3i9pG1kDWAeY27EMGtg==",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.8 || ^8.0.0",
+        "class-transformer": "^0.2.0 || ^0.3.0 || ^0.4.0 || ^0.5.0",
+        "class-validator": "^0.11.1 || ^0.12.0 || ^0.13.0",
+        "reflect-metadata": "^0.1.12"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@nestjs/testing": {
       "version": "8.2.3",
@@ -10751,6 +10797,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/swagger-ui-dist": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.5.0.tgz",
+      "integrity": "sha512-s00bemwjowAeGGCPxj4BmZrTbeKc9ig/99UEuJUVsaDXovIALD5/Hj0tmDCBGT3tgZQ9O7LrBdPmUlyhcudsLQ=="
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.3.0.tgz",
+      "integrity": "sha512-jN46SEEe9EoXa3ZgZoKgnSF6z0w3tnM1yqhO4Y+Q4iZVc8JOQB960EZpIAz6rNROrDApVDwcMHR0mhlnc/5Omw==",
+      "dependencies": {
+        "swagger-ui-dist": ">=4.1.3"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0"
+      }
+    },
     "node_modules/symbol-observable": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
@@ -13670,6 +13735,24 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
           "dev": true
+        }
+      }
+    },
+    "@nestjs/swagger": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-5.2.0.tgz",
+      "integrity": "sha512-wcW2KCe7irwBw0WKsb03uFk4gnjqNcAcJxXGZxi6ljFiDgyLrQtx5MpE95o703tnn4V/hZR8MqMNFOXuup7Pqw==",
+      "requires": {
+        "@nestjs/mapped-types": "1.0.1",
+        "lodash": "4.17.21",
+        "path-to-regexp": "3.2.0"
+      },
+      "dependencies": {
+        "@nestjs/mapped-types": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-1.0.1.tgz",
+          "integrity": "sha512-NFvofzSinp00j5rzUd4tf+xi9od6383iY0JP7o0Bnu1fuItAUkWBgc4EKuIQ3D+c2QI3i9pG1kDWAeY27EMGtg==",
+          "requires": {}
         }
       }
     },
@@ -20175,6 +20258,19 @@
       "requires": {
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
+      }
+    },
+    "swagger-ui-dist": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.5.0.tgz",
+      "integrity": "sha512-s00bemwjowAeGGCPxj4BmZrTbeKc9ig/99UEuJUVsaDXovIALD5/Hj0tmDCBGT3tgZQ9O7LrBdPmUlyhcudsLQ=="
+    },
+    "swagger-ui-express": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.3.0.tgz",
+      "integrity": "sha512-jN46SEEe9EoXa3ZgZoKgnSF6z0w3tnM1yqhO4Y+Q4iZVc8JOQB960EZpIAz6rNROrDApVDwcMHR0mhlnc/5Omw==",
+      "requires": {
+        "swagger-ui-dist": ">=4.1.3"
       }
     },
     "symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@nestjs/core": "8.2.3",
     "@nestjs/platform-express": "8.2.3",
     "@nestjs/schedule": "1.0.2",
+    "@nestjs/swagger": "5.2.0",
     "@studiohyperdrive/pagination": "1.0.0",
     "class-transformer": "0.5.1",
     "class-validator": "0.13.2",
@@ -52,6 +53,7 @@
     "rimraf": "3.0.2",
     "rxjs": "7.4.0",
     "saml2-js": "3.0.1",
+    "swagger-ui-express": "4.3.0",
     "xml-js": "1.6.11"
   },
   "devDependencies": {

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,7 +1,9 @@
 import { Controller, Get } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 
 import { AppService } from './app.service';
 
+@ApiTags('Status')
 @Controller()
 export class AppController {
 	constructor(private readonly appService: AppService) {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { ValidationPipe } from '@nestjs/common';
 import { ConfigService as NestConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import session from 'express-session';
 import helmet from 'helmet';
 
@@ -27,7 +28,19 @@ async function bootstrap() {
 	const sessionConfig = await sessionService.getSessionConfig();
 	app.use(session(sessionConfig));
 
+	/** Swagger docs **/
+	if (process.env.NODE_ENV !== 'production') {
+		const config = new DocumentBuilder()
+			.setTitle('HetArchief2.0 Leeszalen tool API docs')
+			.setDescription('Documentatie voor de leeszalen tool api calls')
+			.setVersion('0.1.0')
+			.build();
+		const document = SwaggerModule.createDocument(app, config);
+		SwaggerModule.setup('docs', app, document);
+	}
+
 	/** All good, start listening */
 	await app.listen(port);
 }
+
 bootstrap();

--- a/src/modules/auth/controllers/auth.controller.ts
+++ b/src/modules/auth/controllers/auth.controller.ts
@@ -8,11 +8,13 @@ import {
 	Redirect,
 	Session,
 } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 
 import { IdpService } from '../services/idp.service';
 import { SessionHelper } from '../session-helper';
 import { LoginMessage, LoginResponse } from '../types';
 
+@ApiTags('Auth')
 @Controller('auth')
 export class AuthController {
 	private logger: Logger = new Logger(AuthController.name, { timestamp: true });

--- a/src/modules/auth/controllers/het-archief.controller.ts
+++ b/src/modules/auth/controllers/het-archief.controller.ts
@@ -10,6 +10,7 @@ import {
 	Session,
 	UnauthorizedException,
 } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 import { get, isEqual, omit } from 'lodash';
 
 import { UsersService } from '../../users/services/users.service';
@@ -17,6 +18,7 @@ import { HetArchiefService } from '../services/het-archief.service';
 import { SessionHelper } from '../session-helper';
 import { Idp, LdapUser, RelayState, SamlCallbackBody } from '../types';
 
+@ApiTags('Auth')
 @Controller('auth/hetarchief')
 export class HetArchiefController {
 	private logger: Logger = new Logger(HetArchiefController.name, { timestamp: true });

--- a/src/modules/auth/controllers/meemoo.controller.ts
+++ b/src/modules/auth/controllers/meemoo.controller.ts
@@ -10,6 +10,7 @@ import {
 	Session,
 	UnauthorizedException,
 } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 import { get, isEqual, omit } from 'lodash';
 
 import { MeemooService } from '../services/meemoo.service';
@@ -18,6 +19,7 @@ import { Idp, LdapUser, RelayState, SamlCallbackBody } from '../types';
 
 import { UsersService } from '~modules/users/services/users.service';
 
+@ApiTags('Auth')
 @Controller('auth/meemoo')
 export class MeemooController {
 	private logger: Logger = new Logger(MeemooController.name, { timestamp: true });

--- a/src/modules/data/controllers/data.controller.ts
+++ b/src/modules/data/controllers/data.controller.ts
@@ -1,8 +1,10 @@
 import { Body, Controller, Post } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 
 import { GraphQlQueryDto } from '../dto/graphql-query.dto';
 import { DataService } from '../services/data.service';
 
+@ApiTags('GraphQL')
 @Controller('data')
 export class DataController {
 	constructor(private dataService: DataService) {}

--- a/src/modules/spaces/controllers/spaces.controller.ts
+++ b/src/modules/spaces/controllers/spaces.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Logger, Param, ParseUUIDPipe, Query } from '@nestjs/common';
-import { ApiBody, ApiTags } from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 import { IPagination } from '@studiohyperdrive/pagination';
 
 import { SpacesQueryDto } from '../dto/spaces.dto';
@@ -14,7 +14,6 @@ export class SpacesController {
 	constructor(private spacesService: SpacesService) {}
 
 	@Get()
-	@ApiBody({ type: SpacesQueryDto, required: false })
 	public async getSpaces(@Query() query: SpacesQueryDto): Promise<IPagination<Space>> {
 		const spaces = await this.spacesService.findAll(query);
 		return spaces;

--- a/src/modules/spaces/controllers/spaces.controller.ts
+++ b/src/modules/spaces/controllers/spaces.controller.ts
@@ -1,10 +1,12 @@
 import { Controller, Get, Logger, Param, ParseUUIDPipe, Query } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 import { IPagination } from '@studiohyperdrive/pagination';
 
 import { SpacesQueryDto } from '../dto/spaces.dto';
 import { SpacesService } from '../services/spaces.service';
 import { Space } from '../types';
 
+@ApiTags('Spaces')
 @Controller('spaces')
 export class SpacesController {
 	private logger: Logger = new Logger(SpacesController.name, { timestamp: true });

--- a/src/modules/spaces/controllers/spaces.controller.ts
+++ b/src/modules/spaces/controllers/spaces.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Logger, Param, ParseUUIDPipe, Query } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiTags } from '@nestjs/swagger';
 import { IPagination } from '@studiohyperdrive/pagination';
 
 import { SpacesQueryDto } from '../dto/spaces.dto';
@@ -14,6 +14,7 @@ export class SpacesController {
 	constructor(private spacesService: SpacesService) {}
 
 	@Get()
+	@ApiBody({ type: SpacesQueryDto, required: false })
 	public async getSpaces(@Query() query: SpacesQueryDto): Promise<IPagination<Space>> {
 		const spaces = await this.spacesService.findAll(query);
 		return spaces;

--- a/src/modules/spaces/dto/spaces.dto.ts
+++ b/src/modules/spaces/dto/spaces.dto.ts
@@ -1,3 +1,4 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsNumber, IsOptional, IsString } from 'class-validator';
 
@@ -9,15 +10,30 @@ export class UpdateSpaceDto {
 export class SpacesQueryDto {
 	@IsString()
 	@IsOptional()
-	query = '%%';
+	@ApiPropertyOptional({
+		type: String,
+		description: "The query to search for. Use '%' for wildcard.",
+		default: '%',
+	})
+	query = '%';
 
 	@IsNumber()
 	@Type(() => Number)
 	@IsOptional()
+	@ApiPropertyOptional({
+		type: Number,
+		description: 'The paging parameter',
+		default: 0,
+	})
 	page = 0;
 
 	@IsNumber()
 	@Type(() => Number)
 	@IsOptional()
+	@ApiPropertyOptional({
+		type: Number,
+		description: 'The max. number of results to return',
+		default: 10,
+	})
 	size = 10;
 }


### PR DESCRIPTION
Enable swagger docs for all servers except production:
under the route:
http://localhost:3100/docs/

![image](https://user-images.githubusercontent.com/1710840/153038395-5a77ee73-8d74-4762-afb5-3f2e08d90254.png)
