### PR TITLE
feat(arc-499): navigations module with crud calls

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import config, { configValidationSchema } from '~config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 
+import { NavigationsModule } from '~modules/admin/navigations';
 import { AuthModule } from '~modules/auth';
 import { DataModule } from '~modules/data';
 import { MediaModule } from '~modules/media';
@@ -27,6 +28,7 @@ import { SessionService } from '~shared/services/session.service';
 		AuthModule,
 		SpacesModule,
 		MediaModule,
+		NavigationsModule,
 		VisitsModule,
 	],
 	controllers: [AppController],

--- a/src/modules/admin/navigations/controllers/navigations.controller.spec.ts
+++ b/src/modules/admin/navigations/controllers/navigations.controller.spec.ts
@@ -18,6 +18,7 @@ const mockNavigationsResponse = {
 const mockNavigationsService = {
 	findAll: jest.fn(),
 	findById: jest.fn(),
+	getNavigationItems: jest.fn(),
 	create: jest.fn(),
 	update: jest.fn(),
 	delete: jest.fn(),
@@ -49,6 +50,16 @@ describe('NavigationsController', () => {
 		it('should return all navigations', async () => {
 			mockNavigationsService.findAll.mockResolvedValueOnce(mockNavigationsResponse);
 			const navigations = await navigationsController.getNavigations({});
+			expect(navigations).toEqual(mockNavigationsResponse);
+		});
+	});
+
+	describe('getNavigationItems', () => {
+		it('should return all navigation items for the user (session)', async () => {
+			mockNavigationsService.getNavigationItems.mockResolvedValueOnce(
+				mockNavigationsResponse
+			);
+			const navigations = await navigationsController.getNavigationItems({});
 			expect(navigations).toEqual(mockNavigationsResponse);
 		});
 	});

--- a/src/modules/admin/navigations/controllers/navigations.controller.spec.ts
+++ b/src/modules/admin/navigations/controllers/navigations.controller.spec.ts
@@ -1,0 +1,97 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { NavigationsService } from '../services/navigations.service';
+
+import { NavigationsController } from './navigations.controller';
+
+const mockNavigationsResponse = {
+	items: [
+		{
+			id: 'navigation-1',
+		},
+		{
+			id: 'navigation-2',
+		},
+	],
+};
+
+const mockNavigationsService = {
+	findAll: jest.fn(),
+	findById: jest.fn(),
+	create: jest.fn(),
+	update: jest.fn(),
+	delete: jest.fn(),
+};
+
+describe('NavigationsController', () => {
+	let navigationsController: NavigationsController;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			controllers: [NavigationsController],
+			imports: [],
+			providers: [
+				{
+					provide: NavigationsService,
+					useValue: mockNavigationsService,
+				},
+			],
+		}).compile();
+
+		navigationsController = module.get<NavigationsController>(NavigationsController);
+	});
+
+	it('should be defined', () => {
+		expect(navigationsController).toBeDefined();
+	});
+
+	describe('getNavigations', () => {
+		it('should return all navigations', async () => {
+			mockNavigationsService.findAll.mockResolvedValueOnce(mockNavigationsResponse);
+			const navigations = await navigationsController.getNavigations({});
+			expect(navigations).toEqual(mockNavigationsResponse);
+		});
+	});
+
+	describe('getNavigation', () => {
+		it('should return a navigation by id', async () => {
+			mockNavigationsService.findById.mockResolvedValueOnce(mockNavigationsResponse.items[0]);
+			const navigations = await navigationsController.getNavigation('navigation-1');
+			expect(navigations).toEqual(mockNavigationsResponse.items[0]);
+		});
+	});
+
+	describe('createNavigation', () => {
+		it('should create a new navigation', async () => {
+			mockNavigationsService.create.mockResolvedValueOnce(mockNavigationsResponse.items[0]);
+			const navigation = await navigationsController.createNavigation({
+				label: 'test-create-nav',
+				icon_name: '',
+				placement: 'footer-links',
+				position: 1,
+			});
+			expect(navigation).toEqual(mockNavigationsResponse.items[0]);
+		});
+	});
+
+	describe('updateNavigation', () => {
+		it('should update a navigation', async () => {
+			mockNavigationsService.update.mockResolvedValueOnce(mockNavigationsResponse.items[0]);
+			const navigation = await navigationsController.updateNavigation('navigation-1', {
+				label: 'test-create-nav',
+				icon_name: '',
+				placement: 'footer-links',
+				position: 1,
+			});
+			expect(navigation).toEqual(mockNavigationsResponse.items[0]);
+		});
+	});
+
+	describe('deleteNavigation', () => {
+		it('should delete a navigation', async () => {
+			mockNavigationsService.delete.mockResolvedValueOnce({ affectedRows: 1 });
+			const navigation = await navigationsController.deleteNavigation('navigation-1');
+			expect(navigation).toEqual({ affectedRows: 1 });
+		});
+	});
+});

--- a/src/modules/admin/navigations/controllers/navigations.controller.ts
+++ b/src/modules/admin/navigations/controllers/navigations.controller.ts
@@ -1,0 +1,54 @@
+import { Body, Controller, Delete, Get, Logger, Param, Post, Put, Query } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { IPagination } from '@studiohyperdrive/pagination/dist/lib/pagination.types';
+
+import { CreateNavigationDto, NavigationsQueryDto } from '../dto/navigations.dto';
+import { NavigationsService } from '../services/navigations.service';
+import { Navigation } from '../types';
+
+import { DeleteResponse } from '~shared/types/types';
+
+@ApiTags('Navigations')
+@Controller('admin/navigations')
+export class NavigationsController {
+	private logger: Logger = new Logger(NavigationsController.name, { timestamp: true });
+
+	constructor(private navigationsService: NavigationsService) {}
+
+	@Get()
+	public async getNavigations(
+		@Query() navigationsQueryDto: NavigationsQueryDto
+	): Promise<IPagination<Navigation>> {
+		const navigations = await this.navigationsService.findAll(navigationsQueryDto);
+		return navigations;
+	}
+
+	@Get(':id')
+	public async getNavigation(@Param('id') id: string): Promise<Navigation> {
+		const navigations = await this.navigationsService.findById(id);
+		return navigations;
+	}
+
+	@Post()
+	public async createNavigation(
+		@Body() createNavigationDto: CreateNavigationDto
+	): Promise<Navigation> {
+		const navigation = await this.navigationsService.create(createNavigationDto);
+		return navigation;
+	}
+
+	@Put(':id')
+	public async updateNavigation(
+		@Param('id') id: string,
+		@Body() updateNavigationDto: CreateNavigationDto
+	): Promise<Navigation> {
+		const navigation = await this.navigationsService.update(id, updateNavigationDto);
+		return navigation;
+	}
+
+	@Delete(':id')
+	public async deleteNavigation(@Param('id') id: string): Promise<DeleteResponse> {
+		const deleted = await this.navigationsService.delete(id);
+		return deleted;
+	}
+}

--- a/src/modules/admin/navigations/controllers/navigations.controller.ts
+++ b/src/modules/admin/navigations/controllers/navigations.controller.ts
@@ -1,4 +1,15 @@
-import { Body, Controller, Delete, Get, Logger, Param, Post, Put, Query } from '@nestjs/common';
+import {
+	Body,
+	Controller,
+	Delete,
+	Get,
+	Logger,
+	Param,
+	Post,
+	Put,
+	Query,
+	Session,
+} from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { IPagination } from '@studiohyperdrive/pagination/dist/lib/pagination.types';
 
@@ -20,6 +31,18 @@ export class NavigationsController {
 		@Query() navigationsQueryDto: NavigationsQueryDto
 	): Promise<IPagination<Navigation>> {
 		const navigations = await this.navigationsService.findAll(navigationsQueryDto);
+		return navigations;
+	}
+
+	/**
+	 * Get navigation items for the current user (logged in or not logged in)
+	 * currently there are not yet special permission groups
+	 */
+	@Get('items')
+	async getNavigationItems(
+		@Session() session: Record<string, any>
+	): Promise<Record<string, Navigation[]>> {
+		const navigations = await this.navigationsService.getNavigationItems(session);
 		return navigations;
 	}
 

--- a/src/modules/admin/navigations/dto/navigations.dto.ts
+++ b/src/modules/admin/navigations/dto/navigations.dto.ts
@@ -1,0 +1,104 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsArray, IsEnum, IsNumber, IsOptional, IsString } from 'class-validator';
+
+import { ContentPickerType, ContentPickerTypeSchema } from '../types';
+
+export class NavigationsQueryDto {
+	@IsString()
+	@IsOptional()
+	@ApiPropertyOptional({
+		type: String,
+		description: 'Get all navigation items with this placement',
+	})
+	placement?: string;
+}
+
+// Note: also used for updating a navigation item
+export class CreateNavigationDto {
+	@IsString()
+	@IsOptional()
+	@ApiPropertyOptional({
+		type: String,
+		description: 'The label for this navigation item',
+	})
+	label?: string;
+
+	@IsString()
+	@ApiProperty({
+		type: String,
+		description: 'The icon for this navigation item',
+	})
+	icon_name = '';
+
+	@IsString()
+	@IsOptional()
+	@ApiPropertyOptional({
+		type: String,
+		description: 'The description for this navigation item',
+	})
+	description?: string;
+
+	@IsArray()
+	@IsOptional()
+	@IsNumber({}, { each: true })
+	@ApiPropertyOptional({
+		type: String,
+		description: 'The user group ids allowed to see this navigation item',
+	})
+	user_group_ids?: Array<number>;
+
+	@ApiProperty({
+		required: false,
+		enum: ContentPickerTypeSchema,
+		description: `The content_type for this item. Options are: ${Object.values(
+			ContentPickerTypeSchema
+		).join(', ')}`,
+	})
+	@IsOptional()
+	@IsEnum(ContentPickerTypeSchema, {
+		message: `content_type must be one of: ${Object.values(ContentPickerTypeSchema).join(
+			', '
+		)}`,
+	})
+	content_type?: ContentPickerType;
+
+	@IsString()
+	@IsOptional()
+	@ApiPropertyOptional({
+		type: String,
+		description: 'The content path for this navigation item, e.g. /help',
+	})
+	content_path?: string;
+
+	@IsString()
+	@IsOptional()
+	@ApiPropertyOptional({
+		type: String,
+		description: 'The link target property for this item, e.g. _blank or _self',
+	})
+	link_target?: string;
+
+	@IsNumber()
+	@Type(() => Number)
+	@ApiProperty({
+		type: Number,
+		description: 'The position of this navigation item. Items are sorted by position.',
+	})
+	position: number;
+
+	@IsString()
+	@ApiProperty({
+		type: String,
+		description: 'The placement for this menu item: e.g. footer-links',
+	})
+	placement: string;
+
+	@IsString()
+	@IsOptional()
+	@ApiPropertyOptional({
+		type: String,
+		description: 'The tooltip shown for this menu item',
+	})
+	tooltip?: string;
+}

--- a/src/modules/admin/navigations/index.ts
+++ b/src/modules/admin/navigations/index.ts
@@ -1,0 +1,1 @@
+export * from './navigations.module';

--- a/src/modules/admin/navigations/navigations.module.ts
+++ b/src/modules/admin/navigations/navigations.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+
+import { NavigationsController } from './controllers/navigations.controller';
+import { NavigationsService } from './services/navigations.service';
+
+import { DataModule } from '~modules/data';
+
+@Module({
+	controllers: [NavigationsController],
+	imports: [DataModule],
+	providers: [NavigationsService],
+})
+export class NavigationsModule {}

--- a/src/modules/admin/navigations/services/navigations.service.spec.ts
+++ b/src/modules/admin/navigations/services/navigations.service.spec.ts
@@ -1,0 +1,165 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { NavigationsService } from './navigations.service';
+
+import { DataService } from '~modules/data/services/data.service';
+
+const mockDataService = {
+	execute: jest.fn(),
+};
+
+describe('NavigationsService', () => {
+	let navigationsService: NavigationsService;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [
+				NavigationsService,
+				{
+					provide: DataService,
+					useValue: mockDataService,
+				},
+			],
+		}).compile();
+
+		navigationsService = module.get<NavigationsService>(NavigationsService);
+	});
+
+	it('services should be defined', () => {
+		expect(navigationsService).toBeDefined();
+	});
+
+	describe('findAll', () => {
+		it('returns a paginated response with all navigations', async () => {
+			mockDataService.execute.mockResolvedValueOnce({
+				data: {
+					cms_navigation_element: [
+						{
+							id: '1',
+						},
+					],
+					cms_navigation_element_aggregate: {
+						aggregate: {
+							count: 100,
+						},
+					},
+				},
+			});
+			const response = await navigationsService.findAll({});
+			expect(response.items.length).toBe(1);
+			expect(response.page).toBe(1);
+			expect(response.size).toBe(100);
+			expect(response.total).toBe(100);
+		});
+
+		it('returns a paginated response with all navigations by placement', async () => {
+			mockDataService.execute.mockResolvedValueOnce({
+				data: {
+					cms_navigation_element: [
+						{
+							id: '1',
+							placement: 'footer-links',
+						},
+					],
+					cms_navigation_element_aggregate: {
+						aggregate: {
+							count: 1,
+						},
+					},
+				},
+			});
+			const response = await navigationsService.findAll({ placement: 'footer-links' });
+			expect(response.items.length).toBe(1);
+			expect(response.items[0].placement).toEqual('footer-links');
+			expect(response.page).toBe(1);
+			expect(response.size).toBe(1);
+			expect(response.total).toBe(1);
+		});
+	});
+
+	describe('findById', () => {
+		it('returns a single navigation', async () => {
+			mockDataService.execute.mockResolvedValueOnce({
+				data: {
+					cms_navigation_element: [
+						{
+							id: '1',
+						},
+					],
+				},
+			});
+			const response = await navigationsService.findById('1');
+			expect(response.id).toBe('1');
+		});
+
+		it('throws a notfoundexception if the navigation was not found', async () => {
+			mockDataService.execute.mockResolvedValueOnce({
+				data: {
+					cms_navigation_element: [],
+				},
+			});
+			let error;
+			try {
+				await navigationsService.findById('unknown-id');
+			} catch (e) {
+				error = e;
+			}
+			expect(error.response).toEqual({
+				message: 'Not Found',
+				statusCode: 404,
+			});
+		});
+	});
+
+	describe('create', () => {
+		it('can create a new navigation', async () => {
+			mockDataService.execute.mockResolvedValueOnce({
+				data: {
+					insert_cms_navigation_element_one: {
+						id: '1',
+					},
+				},
+			});
+			const response = await navigationsService.create({
+				label: 'test-create-nav',
+				icon_name: '',
+				placement: 'footer-links',
+				position: 1,
+			});
+			expect(response.id).toBe('1');
+		});
+	});
+
+	describe('update', () => {
+		it('can update an existing navigation', async () => {
+			mockDataService.execute.mockResolvedValueOnce({
+				data: {
+					update_cms_navigation_element_by_pk: {
+						id: '1',
+					},
+				},
+			});
+			const response = await navigationsService.update('1', {
+				label: 'test-create-nav',
+				icon_name: '',
+				placement: 'footer-links',
+				position: 1,
+			});
+			expect(response.id).toBe('1');
+		});
+	});
+
+	describe('delete', () => {
+		it('can delete a navigation', async () => {
+			mockDataService.execute.mockResolvedValueOnce({
+				data: {
+					delete_cms_navigation_element: {
+						affected_rows: '1',
+					},
+				},
+			});
+			const response = await navigationsService.delete('1');
+			expect(response.affectedRows).toBe('1');
+		});
+	});
+});

--- a/src/modules/admin/navigations/services/navigations.service.ts
+++ b/src/modules/admin/navigations/services/navigations.service.ts
@@ -1,0 +1,84 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { IPagination, Pagination } from '@studiohyperdrive/pagination';
+
+import { CreateNavigationDto, NavigationsQueryDto } from '../dto/navigations.dto';
+import { Navigation } from '../types';
+
+import {
+	DELETE_NAVIGATION,
+	FIND_NAVIGATION_BY_ID,
+	FIND_NAVIGATION_BY_PLACEMENT,
+	FIND_NAVIGATIONS,
+	INSERT_NAVIGATION,
+	UPDATE_NAVIGATION_BY_ID,
+} from './queries.gql';
+
+import { DataService } from '~modules/data/services/data.service';
+import { GraphQlResponse } from '~modules/data/types';
+import { DeleteResponse } from '~shared/types/types';
+
+@Injectable()
+export class NavigationsService {
+	private logger: Logger = new Logger(NavigationsService.name, { timestamp: true });
+
+	constructor(private dataService: DataService) {}
+
+	public async create(navigationItem: CreateNavigationDto): Promise<Navigation> {
+		const {
+			data: { insert_cms_navigation_element_one: createdNavigation },
+		} = await this.dataService.execute(INSERT_NAVIGATION, { navigationItem });
+		this.logger.debug(`Navigation ${createdNavigation.id} created`);
+
+		return createdNavigation;
+	}
+
+	public async update(id: string, navigationItem: CreateNavigationDto): Promise<Navigation> {
+		const {
+			data: { update_cms_navigation_element_by_pk: updatedNavigation },
+		} = await this.dataService.execute(UPDATE_NAVIGATION_BY_ID, { id, navigationItem });
+		this.logger.debug(`Navigation ${updatedNavigation.id} updated`);
+
+		return updatedNavigation;
+	}
+
+	public async delete(id: string): Promise<DeleteResponse> {
+		const {
+			data: {
+				delete_cms_navigation_element: { affected_rows: affectedRows },
+			},
+		} = await this.dataService.execute(DELETE_NAVIGATION, { id });
+
+		return {
+			affectedRows,
+		};
+	}
+
+	public async findAll(
+		navigationsQueryDto: NavigationsQueryDto
+	): Promise<IPagination<Navigation>> {
+		const { placement } = navigationsQueryDto;
+		let navigationsResponse: GraphQlResponse;
+		if (placement) {
+			navigationsResponse = await this.dataService.execute(FIND_NAVIGATION_BY_PLACEMENT, {
+				placement,
+			});
+		} else {
+			navigationsResponse = await this.dataService.execute(FIND_NAVIGATIONS);
+		}
+
+		return Pagination<Navigation>({
+			items: navigationsResponse.data.cms_navigation_element,
+			page: 1,
+			size: navigationsResponse.data.cms_navigation_element_aggregate.aggregate.count,
+			total: navigationsResponse.data.cms_navigation_element_aggregate.aggregate.count,
+		});
+	}
+
+	public async findById(id: string): Promise<Navigation> {
+		const navigationResponse = await this.dataService.execute(FIND_NAVIGATION_BY_ID, { id });
+		if (!navigationResponse.data.cms_navigation_element[0]) {
+			throw new NotFoundException();
+		}
+		return navigationResponse.data.cms_navigation_element[0];
+	}
+}

--- a/src/modules/admin/navigations/services/queries.gql.ts
+++ b/src/modules/admin/navigations/services/queries.gql.ts
@@ -1,0 +1,111 @@
+export const FIND_NAVIGATIONS = `
+	query getNavElements {
+		cms_navigation_element(distinct_on: placement, order_by: { placement: asc }) {
+			id
+			description
+			placement
+			tooltip
+		}
+		cms_navigation_element_aggregate(distinct_on: placement) {
+			aggregate {
+				count
+			}
+		}
+	}
+`;
+
+export const FIND_NAVIGATION_BY_PLACEMENT = `
+	query getMenuItemsByPlacement($placement: String!) {
+		cms_navigation_element(
+			order_by: { position: asc }
+			where: { placement: { _eq: $placement } }
+		) {
+			id
+			created_at
+			description
+			user_group_ids
+			icon_name
+			label
+			link_target
+			placement
+			position
+			updated_at
+			content_type
+			content_path
+			tooltip
+		}
+		cms_navigation_element_aggregate(where: { placement: { _eq: $placement } }) {
+			aggregate {
+				count
+			}
+		}
+	}
+`;
+
+export const FIND_NAVIGATION_BY_ID = `
+	query getMenuItemById($id: uuid!) {
+		cms_navigation_element(where: { id: { _eq: $id } }) {
+			id
+			created_at
+			description
+			user_group_ids
+			icon_name
+			label
+			link_target
+			placement
+			position
+			updated_at
+			content_type
+			content_path
+			tooltip
+		}
+	}
+`;
+
+export const UPDATE_NAVIGATION_BY_ID = `
+	mutation updateMenuItemById($id: uuid!, $navigationItem: cms_navigation_element_set_input!) {
+		update_cms_navigation_element_by_pk(pk_columns: { id: $id }, _set: $navigationItem) {
+			id
+			created_at
+			description
+			user_group_ids
+			icon_name
+			label
+			link_target
+			placement
+			position
+			updated_at
+			content_type
+			content_path
+			tooltip
+		}
+	}
+`;
+
+export const INSERT_NAVIGATION = `
+	mutation insertMenuItem($navigationItem: cms_navigation_element_insert_input!) {
+		insert_cms_navigation_element_one(object: $navigationItem) {
+			id
+			created_at
+			description
+			user_group_ids
+			icon_name
+			label
+			link_target
+			placement
+			position
+			updated_at
+			content_type
+			content_path
+			tooltip
+		}
+	}
+`;
+
+export const DELETE_NAVIGATION = `
+	mutation deleteMenuItemById($id: uuid!) {
+		delete_cms_navigation_element(where: { id: { _eq: $id } }) {
+			affected_rows
+		}
+	}
+`;

--- a/src/modules/admin/navigations/services/queries.gql.ts
+++ b/src/modules/admin/navigations/services/queries.gql.ts
@@ -62,6 +62,27 @@ export const FIND_NAVIGATION_BY_ID = `
 	}
 `;
 
+export const GET_ALL_NAVIGATION_ITEMS = `
+	query getNavigationItems {
+		cms_navigation_element {
+			content_path
+			content_type
+			link_target
+			placement
+			position
+			id
+			icon_name
+			user_group_ids
+			label
+			updated_at
+			description
+			created_at
+			content_id
+			tooltip
+		}
+	}
+`;
+
 export const UPDATE_NAVIGATION_BY_ID = `
 	mutation updateMenuItemById($id: uuid!, $navigationItem: cms_navigation_element_set_input!) {
 		update_cms_navigation_element_by_pk(pk_columns: { id: $id }, _set: $navigationItem) {

--- a/src/modules/admin/navigations/types.ts
+++ b/src/modules/admin/navigations/types.ts
@@ -1,0 +1,42 @@
+export type ContentPickerType =
+	| 'CONTENT_PAGE'
+	| 'COLLECTION'
+	| 'ITEM'
+	| 'BUNDLE'
+	| 'DROPDOWN'
+	| 'INTERNAL_LINK'
+	| 'EXTERNAL_LINK'
+	| 'SEARCH_QUERY'
+	| 'PROJECTS'
+	| 'ANCHOR_LINK'
+	| 'PROFILE';
+
+export enum ContentPickerTypeSchema {
+	CONTENT_PAGE = 'CONTENT_PAGE',
+	COLLECTION = 'COLLECTION',
+	ITEM = 'ITEM',
+	BUNDLE = 'BUNDLE',
+	DROPDOWN = 'DROPDOWN',
+	INTERNAL_LINK = 'INTERNAL_LINK',
+	EXTERNAL_LINK = 'EXTERNAL_LINK',
+	SEARCH_QUERY = 'SEARCH_QUERY',
+	PROJECTS = 'PROJECTS',
+	ANCHOR_LINK = 'ANCHOR_LINK',
+	PROFILE = 'PROFILE',
+}
+
+export interface Navigation {
+	id: string;
+	label: string | null;
+	icon_name: string;
+	description: string | null;
+	user_group_ids: number[] | null;
+	content_type: ContentPickerType | null;
+	content_path: string | number | null;
+	link_target: '_blank' | '_self' | null;
+	position: number;
+	placement: string | null;
+	created_at: string;
+	updated_at: string;
+	tooltip: string | null;
+}

--- a/src/modules/visits/controllers/visits.controller.spec.ts
+++ b/src/modules/visits/controllers/visits.controller.spec.ts
@@ -60,7 +60,7 @@ describe('VisitsController', () => {
 	});
 
 	describe('createVisit', () => {
-		it('should create a visit by id', async () => {
+		it('should create a new visit', async () => {
 			mockVisitsService.create.mockResolvedValueOnce(mockVisitsResponse.items[0]);
 			const visit = await visitsController.createVisit({
 				spaceId: 'space-1',

--- a/src/modules/visits/controllers/visits.controller.ts
+++ b/src/modules/visits/controllers/visits.controller.ts
@@ -15,7 +15,7 @@ export class VisitsController {
 
 	@Get()
 	public async getVisits(@Query() queryDto: VisitsQueryDto): Promise<IPagination<Visit>> {
-		const visits = this.visitsService.findAll(queryDto);
+		const visits = await this.visitsService.findAll(queryDto);
 		return visits;
 	}
 

--- a/src/shared/types/types.ts
+++ b/src/shared/types/types.ts
@@ -1,0 +1,3 @@
+export interface DeleteResponse {
+	affectedRows: number;
+}

--- a/src/shared/types/types.ts
+++ b/src/shared/types/types.ts
@@ -1,3 +1,8 @@
 export interface DeleteResponse {
 	affectedRows: number;
 }
+
+export enum SpecialPermissionGroups {
+	loggedOutUsers = -1,
+	loggedInUsers = -2,
+}


### PR DESCRIPTION
- crud calls for navigations
- extra call to get the navigation items for the current user (based on session): GET admin/navigations/items

Example GET calls:
http://localhost:{{port}}/admin/navigations
http://localhost:{{port}}/admin/navigations?placement=footer-links
http://localhost:{{port}}/admin/navigations/items

POST
![CleanShot 2022-02-17 at 13 47 18](https://user-images.githubusercontent.com/8707395/154484797-8f140d68-4306-4a9a-a45c-49ce91cf24db.png)

PUT
![CleanShot 2022-02-17 at 13 47 34](https://user-images.githubusercontent.com/8707395/154484874-0607e159-dfb5-42b4-b81d-476adbfec3af.png)

DELETE http://localhost:{{port}}/admin/navigations/{{id}}