### PR TITLE
feat(arc-300): improve missing environment variable errors

### DIFF
--- a/.env/.env.template
+++ b/.env/.env.template
@@ -5,6 +5,8 @@ NODE_ENV=local
 PORT=3100
 HOST=http://localhost:${PORT}
 
+CLIENT_HOST=http://localhost:3200
+
 CORS_ENABLE_WHITELIST=false
 
 # GRAPHQL

--- a/src/config/config.types.ts
+++ b/src/config/config.types.ts
@@ -3,6 +3,7 @@ import { ConfigService as NestConfigService } from '@nestjs/config';
 export interface Configuration {
 	environment: string;
 	host: string;
+	clientHost: string;
 	port: number;
 	graphQlUrl: string;
 	graphQlSecret: string;

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,4 +1,5 @@
 import { UnauthorizedException } from '@nestjs/common';
+import { NotImplementedException } from '@nestjs/common/exceptions/not-implemented.exception';
 
 import { DEFAULT_CONFIG } from './config.const';
 import { Configuration } from './config.types';
@@ -13,51 +14,68 @@ const WHITE_LIST_DOMAINS = ['http://localhost:3000'];
  * @returns the cleaned value
  */
 const cleanMultilineEnv = (envVar: string) => {
-	return process.env.NODE_ENV === 'local' ? envVar.replace(/\\n/g, '\n') : envVar;
+	if (!envVar) {
+		return envVar; // Do not crash on empty env vars
+	}
+	return getEnvValue('NODE_ENV', false) === 'local' ? envVar.replace(/\\n/g, '\n') : envVar;
 };
 
-const config = (): Configuration => ({
-	environment: process.env.NODE_ENV || DEFAULT_CONFIG.environment,
-	host: process.env.HOST,
-	port: parseInt(process.env.PORT, 10) || DEFAULT_CONFIG.port,
-	graphQlUrl: process.env.GRAPHQL_URL,
-	graphQlSecret: process.env.GRAPHQL_SECRET,
-	graphQlEnableWhitelist: process.env.GRAPHQL_ENABLE_WHITELIST === 'true',
-	cookieSecret: process.env.COOKIE_SECRET,
-	cookieMaxAge: parseInt(process.env.COOKIE_MAX_AGE, 10),
-	redisConnectionString: process.env.REDIS_CONNECTION_STRING,
-	elasticSearchUrl: process.env.ELASTICSEARCH_URL,
-	samlIdpMetaDataEndpoint: process.env.SAML_IDP_META_DATA_ENDPOINT,
-	samlSpEntityId: process.env.SAML_SP_ENTITY_ID,
-	samlSpPrivateKey: cleanMultilineEnv(process.env.SAML_SP_PRIVATE_KEY),
-	samlSpCertificate: cleanMultilineEnv(process.env.SAML_SP_CERTIFICATE),
-	samlMeemooIdpMetaDataEndpoint: process.env.SAML_MEEMOO_IDP_META_DATA_ENDPOINT,
-	samlMeemooSpEntityId: process.env.SAML_MEEMOO_SP_ENTITY_ID,
-	corsEnableWhitelist: process.env.CORS_ENABLE_WHITELIST === 'true',
-	corsOptions: {
-		origin: (origin: string, callback: (err: Error, allow: boolean) => void) => {
-			if (process.env.CORS_ENABLE_WHITELIST !== 'true') {
-				// whitelist not enabled
-				callback(null, true);
-			} else if (WHITE_LIST_DOMAINS.indexOf(origin) !== -1 || !origin) {
-				// whitelist enabled but not permitted
-				callback(null, true);
-			} else {
-				callback(new UnauthorizedException('Request not allowed by CORS'), false);
-			}
+const getEnvValue = (name: string, required = true): string => {
+	const value = process.env[name];
+	if (!value && required && process.env.NODE_ENV !== 'test') {
+		throw new NotImplementedException(
+			`The environment variable ${name} is not set, but is required to run the service.`
+		);
+	}
+	return value;
+};
+
+const config = (): Configuration => {
+	const env = getEnvValue('NODE_ENV', false) || DEFAULT_CONFIG.environment;
+	return {
+		environment: env,
+		host: getEnvValue('HOST', true),
+		clientHost: getEnvValue('CLIENT_HOST', true),
+		port: parseInt(getEnvValue('PORT', false), 10) || DEFAULT_CONFIG.port,
+		graphQlUrl: getEnvValue('GRAPHQL_URL', true),
+		graphQlSecret: getEnvValue('GRAPHQL_SECRET', env !== 'local'), // Not required on localhost
+		graphQlEnableWhitelist: getEnvValue('GRAPHQL_ENABLE_WHITELIST', false) === 'true',
+		cookieSecret: getEnvValue('COOKIE_SECRET', true),
+		cookieMaxAge: parseInt(getEnvValue('COOKIE_MAX_AGE', true), 10),
+		redisConnectionString: getEnvValue('REDIS_CONNECTION_STRING', false),
+		elasticSearchUrl: getEnvValue('ELASTICSEARCH_URL', true),
+		samlIdpMetaDataEndpoint: getEnvValue('SAML_IDP_META_DATA_ENDPOINT', true),
+		samlSpEntityId: getEnvValue('SAML_SP_ENTITY_ID', true),
+		samlSpPrivateKey: cleanMultilineEnv(getEnvValue('SAML_SP_PRIVATE_KEY', false)),
+		samlSpCertificate: cleanMultilineEnv(getEnvValue('SAML_SP_CERTIFICATE', false)),
+		samlMeemooIdpMetaDataEndpoint: getEnvValue('SAML_MEEMOO_IDP_META_DATA_ENDPOINT', true),
+		samlMeemooSpEntityId: getEnvValue('SAML_MEEMOO_SP_ENTITY_ID', true),
+		corsEnableWhitelist: getEnvValue('CORS_ENABLE_WHITELIST', false) === 'true',
+		corsOptions: {
+			origin: (origin: string, callback: (err: Error, allow: boolean) => void) => {
+				if (getEnvValue('CORS_ENABLE_WHITELIST', false) !== 'true') {
+					// whitelist not enabled
+					callback(null, true);
+				} else if (WHITE_LIST_DOMAINS.indexOf(origin) !== -1 || !origin) {
+					// whitelist enabled but not permitted
+					callback(null, true);
+				} else {
+					callback(new UnauthorizedException('Request not allowed by CORS'), false);
+				}
+			},
+			credentials: true,
+			allowedHeaders:
+				'X-Requested-With, Content-Type, authorization, Origin, Accept, cache-control',
+			methods: 'GET, POST, OPTIONS, PATCH, PUT, DELETE',
 		},
-		credentials: true,
-		allowedHeaders:
-			'X-Requested-With, Content-Type, authorization, Origin, Accept, cache-control',
-		methods: 'GET, POST, OPTIONS, PATCH, PUT, DELETE',
-	},
-	ticketServiceUrl: process.env.TICKET_SERVICE_URL,
-	ticketServiceCertificate: cleanMultilineEnv(process.env.TICKET_SERVICE_CERT),
-	ticketServiceKey: cleanMultilineEnv(process.env.TICKET_SERVICE_KEY),
-	ticketServicePassphrase: process.env.TICKET_SERVICE_PASSPHRASE,
-	ticketServiceMaxAge: parseInt(process.env.TICKET_SERVICE_MAXAGE, 10),
-	mediaServiceUrl: process.env.MEDIA_SERVICE_URL,
-});
+		ticketServiceUrl: getEnvValue('TICKET_SERVICE_URL', true),
+		ticketServiceCertificate: cleanMultilineEnv(getEnvValue('TICKET_SERVICE_CERT', true)),
+		ticketServiceKey: cleanMultilineEnv(getEnvValue('TICKET_SERVICE_KEY', true)),
+		ticketServicePassphrase: getEnvValue('TICKET_SERVICE_PASSPHRASE', true),
+		ticketServiceMaxAge: parseInt(getEnvValue('TICKET_SERVICE_MAXAGE', true), 10),
+		mediaServiceUrl: getEnvValue('MEDIA_SERVICE_URL', true),
+	};
+};
 
 export default config;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,13 +29,13 @@ async function bootstrap() {
 	app.use(session(sessionConfig));
 
 	/** Swagger docs **/
-	if (process.env.NODE_ENV !== 'production') {
-		const config = new DocumentBuilder()
+	if (configService.get('environment') !== 'production') {
+		const swaggerConfig = new DocumentBuilder()
 			.setTitle('HetArchief2.0 Leeszalen tool API docs')
 			.setDescription('Documentatie voor de leeszalen tool api calls')
 			.setVersion('0.1.0')
 			.build();
-		const document = SwaggerModule.createDocument(app, config);
+		const document = SwaggerModule.createDocument(app, swaggerConfig);
 		SwaggerModule.setup('docs', app, document);
 	}
 

--- a/src/modules/auth/controllers/auth.controller.ts
+++ b/src/modules/auth/controllers/auth.controller.ts
@@ -8,6 +8,7 @@ import {
 	Redirect,
 	Session,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { ApiTags } from '@nestjs/swagger';
 
 import { IdpService } from '../services/idp.service';
@@ -19,7 +20,7 @@ import { LoginMessage, LoginResponse } from '../types';
 export class AuthController {
 	private logger: Logger = new Logger(AuthController.name, { timestamp: true });
 
-	constructor(private idpService: IdpService) {}
+	constructor(private idpService: IdpService, private configService: ConfigService) {}
 
 	@Get('check-login')
 	public async checkLogin(@Session() session: Record<string, any>): Promise<LoginResponse> {
@@ -70,14 +71,14 @@ export class AuthController {
 	 */
 	@Get('session')
 	public getSession(@Session() session: Record<string, any>) {
-		if (process.env.NODE_ENV !== 'production') {
+		if (this.configService.get('environment') !== 'production') {
 			return session;
 		}
 	}
 
 	@Post('session')
 	public postSession(@Session() session: Record<string, any>) {
-		if (process.env.NODE_ENV !== 'production') {
+		if (this.configService.get('environment') !== 'production') {
 			return session;
 		}
 	}

--- a/src/modules/auth/controllers/het-archief.controller.spec.ts
+++ b/src/modules/auth/controllers/het-archief.controller.spec.ts
@@ -40,17 +40,26 @@ const samlLogoutResponse = {
 	SAMLResponse: 'dummy',
 };
 
-const mockArchiefService = {
+const mockArchiefService: Partial<Record<keyof HetArchiefService, jest.SpyInstance>> = {
 	createLoginRequestUrl: jest.fn(),
 	assertSamlResponse: jest.fn(),
 	createLogoutRequestUrl: jest.fn(),
 	createLogoutResponseUrl: jest.fn(),
 };
 
-const mockUsersService = {
+const mockUsersService: Partial<Record<keyof UsersService, jest.SpyInstance>> = {
 	getUserByIdentityId: jest.fn(),
 	createUserWithIdp: jest.fn(),
 	updateUser: jest.fn(),
+};
+
+const mockConfigService: Partial<Record<keyof ConfigService, jest.SpyInstance>> = {
+	get: jest.fn((key: string): string | boolean => {
+		if (key === 'clientHost') {
+			return 'http://localhost:3200';
+		}
+		return key;
+	}),
 };
 
 const getNewMockSession = () => ({
@@ -79,7 +88,7 @@ describe('HetArchiefController', () => {
 				},
 				{
 					provide: ConfigService,
-					useValue: new ConfigService(),
+					useValue: mockConfigService,
 				},
 			],
 		}).compile();
@@ -95,7 +104,7 @@ describe('HetArchiefController', () => {
 	describe('login', () => {
 		it('should redirect to the login url', async () => {
 			mockArchiefService.createLoginRequestUrl.mockReturnValueOnce(hetArchiefLoginUrl);
-			const result = await hetArchiefController.getAuth({}, configService.get('CLIENT_HOST'));
+			const result = await hetArchiefController.getAuth({}, configService.get('clientHost'));
 			expect(result).toEqual({
 				statusCode: HttpStatus.TEMPORARY_REDIRECT,
 				url: hetArchiefLoginUrl,
@@ -105,11 +114,11 @@ describe('HetArchiefController', () => {
 		it('should immediately redirect to the returnUrl if there is a valid session', async () => {
 			const result = await hetArchiefController.getAuth(
 				getNewMockSession(),
-				configService.get('CLIENT_HOST')
+				configService.get('clientHost')
 			);
 			expect(result).toEqual({
 				statusCode: HttpStatus.TEMPORARY_REDIRECT,
-				url: configService.get('CLIENT_HOST'),
+				url: configService.get('clientHost'),
 			});
 		});
 
@@ -117,7 +126,7 @@ describe('HetArchiefController', () => {
 			mockArchiefService.createLoginRequestUrl.mockImplementationOnce(() => {
 				throw new Error('Test error handling');
 			});
-			const result = await hetArchiefController.getAuth({}, configService.get('CLIENT_HOST'));
+			const result = await hetArchiefController.getAuth({}, configService.get('clientHost'));
 			expect(result).toBeUndefined();
 		});
 	});
@@ -232,7 +241,7 @@ describe('HetArchiefController', () => {
 			const mockSession = getNewMockSession();
 			const result = await hetArchiefController.logout(
 				mockSession,
-				configService.get('CLIENT_HOST')
+				configService.get('clientHost')
 			);
 			expect(result).toEqual({
 				statusCode: HttpStatus.TEMPORARY_REDIRECT,
@@ -246,11 +255,11 @@ describe('HetArchiefController', () => {
 			mockSession.idp = null;
 			const result = await hetArchiefController.logout(
 				mockSession,
-				configService.get('CLIENT_HOST')
+				configService.get('clientHost')
 			);
 			expect(result).toEqual({
 				statusCode: HttpStatus.TEMPORARY_REDIRECT,
-				url: configService.get('CLIENT_HOST'),
+				url: configService.get('clientHost'),
 			});
 		});
 
@@ -260,7 +269,7 @@ describe('HetArchiefController', () => {
 			});
 			const result = await hetArchiefController.logout(
 				getNewMockSession(),
-				configService.get('CLIENT_HOST')
+				configService.get('clientHost')
 			);
 			expect(result).toBeUndefined();
 		});

--- a/src/modules/auth/controllers/het-archief.controller.ts
+++ b/src/modules/auth/controllers/het-archief.controller.ts
@@ -10,6 +10,7 @@ import {
 	Session,
 	UnauthorizedException,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { ApiTags } from '@nestjs/swagger';
 import { get, isEqual, omit } from 'lodash';
 
@@ -23,7 +24,11 @@ import { Idp, LdapUser, RelayState, SamlCallbackBody } from '../types';
 export class HetArchiefController {
 	private logger: Logger = new Logger(HetArchiefController.name, { timestamp: true });
 
-	constructor(private hetArchiefService: HetArchiefService, private usersService: UsersService) {}
+	constructor(
+		private hetArchiefService: HetArchiefService,
+		private usersService: UsersService,
+		private configService: ConfigService
+	) {}
 
 	@Get('login')
 	@Redirect()
@@ -118,7 +123,9 @@ export class HetArchiefController {
 		} catch (err) {
 			if (err.message === 'SAML Response is no longer valid') {
 				return {
-					url: `${process.env.HOST}/auth/hetarchief/login&returnToUrl=${info.returnToUrl}`,
+					url: `${this.configService.get('host')}/auth/hetarchief/login&returnToUrl=${
+						info.returnToUrl
+					}`,
 					statusCode: HttpStatus.TEMPORARY_REDIRECT,
 				};
 			}

--- a/src/modules/auth/controllers/meemoo.controller.spec.ts
+++ b/src/modules/auth/controllers/meemoo.controller.spec.ts
@@ -1,4 +1,5 @@
 import { HttpStatus } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { MeemooService } from '../services/meemoo.service';
@@ -62,6 +63,8 @@ const getNewMockSession = () => ({
 
 describe('MeemooController', () => {
 	let meemooController: MeemooController;
+	let configService: ConfigService;
+
 	beforeEach(async () => {
 		const module: TestingModule = await Test.createTestingModule({
 			controllers: [MeemooController],
@@ -74,10 +77,15 @@ describe('MeemooController', () => {
 					provide: UsersService,
 					useValue: mockUsersService,
 				},
+				{
+					provide: ConfigService,
+					useValue: new ConfigService(),
+				},
 			],
 		}).compile();
 
 		meemooController = module.get<MeemooController>(MeemooController);
+		configService = module.get<ConfigService>(ConfigService);
 	});
 
 	it('should be defined', () => {
@@ -210,7 +218,7 @@ describe('MeemooController', () => {
 			});
 			const response = await meemooController.loginCallback({}, samlResponse);
 			expect(response).toEqual({
-				url: `${process.env.HOST}/auth/meemoo/login&returnToUrl=${meemooLoginUrl}`,
+				url: `${configService.get('host')}/auth/meemoo/login&returnToUrl=${meemooLoginUrl}`,
 				statusCode: HttpStatus.TEMPORARY_REDIRECT,
 			});
 		});

--- a/src/modules/auth/controllers/meemoo.controller.ts
+++ b/src/modules/auth/controllers/meemoo.controller.ts
@@ -10,6 +10,7 @@ import {
 	Session,
 	UnauthorizedException,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { ApiTags } from '@nestjs/swagger';
 import { get, isEqual, omit } from 'lodash';
 
@@ -24,7 +25,11 @@ import { UsersService } from '~modules/users/services/users.service';
 export class MeemooController {
 	private logger: Logger = new Logger(MeemooController.name, { timestamp: true });
 
-	constructor(private meemooService: MeemooService, private usersService: UsersService) {}
+	constructor(
+		private meemooService: MeemooService,
+		private usersService: UsersService,
+		private configService: ConfigService
+	) {}
 
 	@Get('login')
 	@Redirect()
@@ -121,7 +126,9 @@ export class MeemooController {
 		} catch (err) {
 			if (err.message === 'SAML Response is no longer valid') {
 				return {
-					url: `${process.env.HOST}/auth/meemoo/login&returnToUrl=${info.returnToUrl}`,
+					url: `${this.configService.get('host')}/auth/meemoo/login&returnToUrl=${
+						info.returnToUrl
+					}`,
 					statusCode: HttpStatus.TEMPORARY_REDIRECT,
 				};
 			}

--- a/src/modules/auth/services/saml.service.ts
+++ b/src/modules/auth/services/saml.service.ts
@@ -19,7 +19,7 @@ export abstract class SamlService {
 
 	public async init(samlConfig: SamlConfig) {
 		const { url, entityId, privateKey, certificate, assertEndpoint } = samlConfig;
-		if (process.env.NODE_ENV !== 'production') {
+		if (this.configService.get('environment') !== 'production') {
 			this.logger.log('SAML config ', {
 				url,
 				entityId,

--- a/src/modules/data/services/data.service.ts
+++ b/src/modules/data/services/data.service.ts
@@ -28,7 +28,7 @@ export class DataService {
 		private configService: ConfigService,
 		private dataPermissionsService: DataPermissionsService
 	) {
-		if (process.env.NODE_ENV !== 'production') {
+		if (configService.get('environment') !== 'production') {
 			this.logger.log('GraphQl config: ', {
 				url: this.configService.get('graphQlUrl'),
 				secret: this.configService.get('graphQlSecret'),


### PR DESCRIPTION
Missing environment variables that are required for the service to run, now throw error messages:
```
st] 8828  - 02/28/2022, 9:53:12 AM     LOG [NestFactory] Starting Nest application...
[Nest] 8828  - 02/28/2022, 9:53:12 AM   ERROR [ExceptionHandler] The environment variable TICKET_SERVICE_URL is not set, but is required to run the service.
NotImplementedException: The environment variable TICKET_SERVICE_URL is not set, but is required to run the service.
    at getEnvValue (C:\Users\bert\Documents\studiohyperdrive\repos\hetarchief-proxy\src\config\index.ts:28:9)
    at InstanceWrapper.config [as metatype] (C:\Users\bert\Documents\studiohyperdrive\repos\hetarchief-proxy\src\config\index.ts:72:21)
    at Injector.instantiateClass (C:\Users\bert\Documents\studiohyperdrive\repos\hetarchief-proxy\node_modules\@nestjs\core\injector\injector.js:304:55)
    at callback (C:\Users\bert\Documents\studiohyperdrive\repos\hetarchief-proxy\node_modules\@nestjs\core\injector\injector.js:48:41)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at Injector.resolveConstructorParams (C:\Users\bert\Documents\studiohyperdrive\repos\hetarchief-proxy\node_modules\@nestjs\core\injector\injector.js:124:24)
    at Injector.loadInstance (C:\Users\bert\Documents\studiohyperdrive\repos\hetarchief-proxy\node_modules\@nestjs\core\injector\injector.js:52:9)
    at Injector.loadProvider (C:\Users\bert\Documents\studiohyperdrive\repos\hetarchief-proxy\node_modules\@nestjs\core\injector\injector.js:74:9)
    at async Promise.all (index 4)
    at InstanceLoader.createInstancesOfProviders (C:\Users\bert\Documents\studiohyperdrive\repos\hetarchief-proxy\node_modules\@nestjs\core\injector\instance-loader.js:44:9)
Waiting for the debugger to disconnect...
```