### PR TITLE
feat(arc-283): add routes for getting notifications and marking as read

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,6 +12,7 @@ import { AuthModule } from '~modules/auth';
 import { CollectionsModule } from '~modules/collections';
 import { DataModule } from '~modules/data';
 import { MediaModule } from '~modules/media';
+import { NotificationsModule } from '~modules/notifications';
 import { SpacesModule } from '~modules/spaces';
 import { TosModule } from '~modules/tos';
 import { UsersModule } from '~modules/users';
@@ -37,6 +38,7 @@ import { SessionService } from '~shared/services/session.service';
 		UsersModule,
 		VisitsModule,
 		CollectionsModule,
+		NotificationsModule,
 	],
 	controllers: [AppController],
 	providers: [AppService, SessionService],

--- a/src/modules/notifications/controllers/notifications.controller.spec.ts
+++ b/src/modules/notifications/controllers/notifications.controller.spec.ts
@@ -1,0 +1,115 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { IPagination } from '@studiohyperdrive/pagination';
+
+import { NotificationsService } from '../services/notifications.service';
+
+import { NotificationsController } from './notifications.controller';
+
+import { Notification, NotificationStatus, NotificationType } from '~modules/notifications/types';
+import { User } from '~modules/users/types';
+import { SessionHelper } from '~shared/auth/session-helper';
+
+const mockNotification1 = {
+	description:
+		'Je bezoek aanvraag aan de leeszaal van Gents museum is goedgekeurd, je hebt toegang van 12:00 to 16:00 op 17 feb 2022',
+	title: 'Je bezoek aanvraag is goedgekeurd',
+	id: 'b925aca7-2e57-4f8e-a46b-13625c512fc2',
+	status: NotificationStatus.UNREAD,
+	visitId: '0fb12a25-a882-42f7-9c79-9d77839c7237',
+	createdAt: '2022-02-28T17:21:58.937169+00:00',
+	updatedAt: '2022-02-28T17:21:58.937169',
+	notificationType: NotificationType.VISIT_REQUEST_APPROVED,
+	showAt: '2022-02-28T17:29:53.478639',
+};
+
+const mockNotification2 = {
+	description:
+		'Je bezoek aanvraag aan de leeszaal van Gents museum is goedgekeurd, je hebt toegang van 12:00 to 16:00 op 17 feb 2022',
+	title: 'Je bezoek aanvraag is goedgekeurd',
+	id: '84056059-c9fe-409b-844e-e7ce606c6212',
+	status: NotificationStatus.UNREAD,
+	visitId: '0fb12a25-a882-42f7-9c79-9d77839c7237',
+	createdAt: '2022-02-25T17:21:58.937169+00:00',
+	updatedAt: '2022-02-25T17:21:58.937169',
+	notificationType: NotificationType.VISIT_REQUEST_APPROVED,
+	showAt: '2022-02-25T17:29:53.478639',
+};
+
+const mockNotificationsResponse: IPagination<Notification> = {
+	items: [mockNotification1, mockNotification2],
+	total: 2,
+	pages: 1,
+	page: 1,
+	size: 20,
+};
+
+const mockUser: User = {
+	id: 'e791ecf1-e121-4c54-9d2e-34524b6467c6',
+	firstName: 'Test',
+	lastName: 'Testers',
+	email: 'test.testers@meemoo.be',
+	acceptedTosAt: '1997-01-01T00:00:00.000Z',
+};
+
+const mockNotificationsService: Partial<Record<keyof NotificationsService, jest.SpyInstance>> = {
+	findNotificationsByUser: jest.fn(),
+	create: jest.fn(),
+	update: jest.fn(),
+};
+
+describe('NotificationsController', () => {
+	let notificationsController: NotificationsController;
+	let sessionHelperSpy: jest.SpyInstance;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			controllers: [NotificationsController],
+			imports: [],
+			providers: [
+				{
+					provide: NotificationsService,
+					useValue: mockNotificationsService,
+				},
+			],
+		}).compile();
+
+		notificationsController = module.get<NotificationsController>(NotificationsController);
+
+		sessionHelperSpy = jest
+			.spyOn(SessionHelper, 'getArchiefUserInfo')
+			.mockReturnValue(mockUser);
+	});
+
+	afterEach(async () => {
+		sessionHelperSpy.mockRestore();
+	});
+
+	it('should be defined', () => {
+		expect(notificationsController).toBeDefined();
+	});
+
+	describe('getNotifications', () => {
+		it('should return all notifications for a specific user', async () => {
+			mockNotificationsService.findNotificationsByUser.mockResolvedValueOnce(
+				mockNotificationsResponse
+			);
+			const notifications = await notificationsController.getNotifications(
+				{ page: 1, size: 20 },
+				{}
+			);
+			expect(notifications.items.length).toEqual(2);
+		});
+	});
+
+	describe('markAsRead', () => {
+		it('should mark a notification as read', async () => {
+			mockNotificationsService.update.mockResolvedValueOnce({
+				...mockNotification1,
+				status: NotificationStatus.READ,
+			});
+			const notification = await notificationsController.markAsRead(mockNotification1.id, {});
+			expect(notification.id).toEqual(mockNotification1.id);
+			expect(notification.status).toEqual(NotificationStatus.READ);
+		});
+	});
+});

--- a/src/modules/notifications/controllers/notifications.controller.ts
+++ b/src/modules/notifications/controllers/notifications.controller.ts
@@ -1,0 +1,46 @@
+import { Controller, Get, Param, Put, Query, Session, UseGuards } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { IPagination } from '@studiohyperdrive/pagination';
+import { addMonths } from 'date-fns';
+
+import { Notification, NotificationStatus } from '../types';
+
+import { NotificationsQueryDto } from '~modules/notifications/dto/notifications.dto';
+import { NotificationsService } from '~modules/notifications/services/notifications.service';
+import { SessionHelper } from '~shared/auth/session-helper';
+import { LoggedInGuard } from '~shared/guards/logged-in.guard';
+
+@UseGuards(LoggedInGuard)
+@ApiTags('Notifications')
+@Controller('notifications')
+export class NotificationsController {
+	constructor(private notificationsService: NotificationsService) {}
+
+	@Get()
+	public async getNotifications(
+		@Query() queryDto: NotificationsQueryDto,
+		@Session() session: Record<string, any>
+	): Promise<IPagination<Notification>> {
+		const userInfo = SessionHelper.getArchiefUserInfo(session);
+		const notifications = await this.notificationsService.findNotificationsByUser(
+			userInfo.id,
+			addMonths(new Date(), -1).toISOString(),
+			queryDto.page,
+			queryDto.size
+		);
+		return notifications;
+	}
+
+	@Put(':notificationId')
+	public async markAsRead(
+		@Param('notificationId') notificationId: string,
+		@Session() session: Record<string, any>
+	): Promise<Notification> {
+		const notification = await this.notificationsService.update(
+			notificationId,
+			SessionHelper.getArchiefUserInfo(session).id,
+			{ status: NotificationStatus.READ }
+		);
+		return notification;
+	}
+}

--- a/src/modules/notifications/dto/notifications.dto.ts
+++ b/src/modules/notifications/dto/notifications.dto.ts
@@ -1,0 +1,25 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsNumber, IsOptional } from 'class-validator';
+
+export class NotificationsQueryDto {
+	@IsNumber()
+	@Type(() => Number)
+	@IsOptional()
+	@ApiPropertyOptional({
+		type: Number,
+		description: 'Which page of results to fetch. Counting starts at 1',
+		default: 1,
+	})
+	page? = 1;
+
+	@IsNumber()
+	@Type(() => Number)
+	@IsOptional()
+	@ApiPropertyOptional({
+		type: Number,
+		description: 'The max. number of results to return',
+		default: 10,
+	})
+	size? = 10;
+}

--- a/src/modules/notifications/index.ts
+++ b/src/modules/notifications/index.ts
@@ -1,0 +1,1 @@
+export * from './notifications.module';

--- a/src/modules/notifications/notifications.module.ts
+++ b/src/modules/notifications/notifications.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+
+import { NotificationsController } from './controllers/notifications.controller';
+import { NotificationsService } from './services/notifications.service';
+
+import { DataModule } from '~modules/data';
+
+@Module({
+	controllers: [NotificationsController],
+	imports: [DataModule],
+	providers: [NotificationsService],
+	exports: [NotificationsService],
+})
+export class NotificationsModule {}

--- a/src/modules/notifications/services/__mocks__/app_notification.ts
+++ b/src/modules/notifications/services/__mocks__/app_notification.ts
@@ -1,0 +1,19 @@
+import {
+	GqlNotification,
+	NotificationStatus,
+	NotificationType,
+} from '~modules/notifications/types';
+
+export const mockGqlNotification: GqlNotification = {
+	id: 'b925aca7-2e57-4f8e-a46b-13625c512fc2',
+	description:
+		'Je bezoek aanvraag aan de leeszaal van Gents museum is goedgekeurd, je hebt toegang van 12:00 to 16:00 op 17 feb 2022',
+	title: 'Je bezoek aanvraag is goedgekeurd',
+	status: NotificationStatus.UNREAD,
+	notification_type: NotificationType.VISIT_REQUEST_APPROVED,
+	recipient: 'df8024f9-ebdc-4f45-8390-72980a3f29f6',
+	visit_id: '0fb12a25-a882-42f7-9c79-9d77839c7237',
+	show_at: '2022-02-28T17:29:53.478639',
+	created_at: '2022-02-28T17:21:58.937169+00:00',
+	updated_at: '2022-02-28T17:21:58.937169',
+};

--- a/src/modules/notifications/services/notifications.service.spec.ts
+++ b/src/modules/notifications/services/notifications.service.spec.ts
@@ -1,0 +1,156 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { addMonths } from 'date-fns';
+
+import { NotificationsService } from './notifications.service';
+
+import { DataService } from '~modules/data/services/data.service';
+import { mockGqlNotification } from '~modules/notifications/services/__mocks__/app_notification';
+import { NotificationStatus, NotificationType } from '~modules/notifications/types';
+
+const mockDataService: Partial<Record<keyof DataService, jest.SpyInstance>> = {
+	execute: jest.fn(),
+};
+
+const mockGqlNotification1 = {
+	description:
+		'Je bezoek aanvraag aan de leeszaal van Gents museum is goedgekeurd, je hebt toegang van 12:00 to 16:00 op 17 feb 2022',
+	title: 'Je bezoek aanvraag is goedgekeurd',
+	id: 'b925aca7-2e57-4f8e-a46b-13625c512fc2',
+	status: NotificationStatus.UNREAD,
+	recipient: 'df8024f9-ebdc-4f45-8390-72980a3f29f6',
+	visit_id: '0fb12a25-a882-42f7-9c79-9d77839c7237',
+	created_at: '2022-02-28T17:21:58.937169+00:00',
+	updated_at: '2022-02-28T17:21:58.937169',
+	notification_type: NotificationType.VISIT_REQUEST_APPROVED,
+	show_at: '2022-02-28T17:29:53.478639',
+};
+
+const mockGqlNotification2 = {
+	description:
+		'Je bezoek aanvraag aan de leeszaal van Gents museum is goedgekeurd, je hebt toegang van 12:00 to 16:00 op 17 feb 2022',
+	title: 'Je bezoek aanvraag is goedgekeurd',
+	id: '84056059-c9fe-409b-844e-e7ce606c6212',
+	status: NotificationStatus.UNREAD,
+	recipient: 'df8024f9-ebdc-4f45-8390-72980a3f29f6',
+	visit_id: '0fb12a25-a882-42f7-9c79-9d77839c7237',
+	created_at: '2022-02-25T17:21:58.937169+00:00',
+	updated_at: '2022-02-25T17:21:58.937169',
+	notification_type: NotificationType.VISIT_REQUEST_APPROVED,
+	show_at: '2022-02-25T17:29:53.478639',
+};
+
+const mockGqlNotificationsResult = {
+	data: {
+		app_notification: [mockGqlNotification1, mockGqlNotification2],
+	},
+};
+
+const mockUser = {
+	id: 'e791ecf1-e121-4c54-9d2e-34524b6467c6',
+	firstName: 'Test',
+	lastName: 'Testers',
+	email: 'test.testers@meemoo.be',
+};
+
+describe('NotificationsService', () => {
+	let notificationsService: NotificationsService;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [
+				NotificationsService,
+				{
+					provide: DataService,
+					useValue: mockDataService,
+				},
+			],
+		}).compile();
+
+		notificationsService = module.get<NotificationsService>(NotificationsService);
+	});
+
+	it('services should be defined', () => {
+		expect(notificationsService).toBeDefined();
+	});
+
+	describe('adapt', () => {
+		it('can adapt a graphql notification response to our notification interface', () => {
+			const adapted = notificationsService.adaptNotification(mockGqlNotification);
+			// test some sample keys
+			expect(adapted.id).toEqual(mockGqlNotification.id);
+			expect(adapted.showAt).toEqual(mockGqlNotification.show_at);
+			expect(adapted.notificationType).toEqual(mockGqlNotification.notification_type);
+		});
+	});
+
+	describe('findByUser', () => {
+		it('returns a paginated response with all notifications for a user', async () => {
+			mockDataService.execute.mockResolvedValueOnce(mockGqlNotificationsResult);
+			const response = await notificationsService.findNotificationsByUser(
+				mockGqlNotificationsResult.data.app_notification[0].recipient,
+				addMonths(new Date(), -1).toISOString(),
+				1,
+				20
+			);
+			expect(response.items.length).toBe(2);
+			expect(response.page).toBe(1);
+			expect(response.size).toBe(20);
+			expect(response.total).toBe(2);
+		});
+	});
+
+	describe('create', () => {
+		it('can create a new notification', async () => {
+			mockDataService.execute.mockResolvedValueOnce({
+				data: {
+					insert_app_notification: {
+						returning: [mockGqlNotification1],
+					},
+				},
+			});
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			const { id, created_at, updated_at, ...mockNotification } = mockGqlNotification1;
+			const response = await notificationsService.create(mockNotification);
+			expect(response.id).toBe(mockGqlNotification1.id);
+		});
+	});
+
+	describe('update', () => {
+		it('can update a notification', async () => {
+			mockDataService.execute.mockResolvedValueOnce({
+				data: {
+					update_app_notification: {
+						returning: [mockGqlNotification1],
+					},
+				},
+			});
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			const { id, created_at, updated_at, ...mockNotification } = mockGqlNotification1;
+			const response = await notificationsService.update(id, mockUser.id, mockNotification);
+			expect(response.id).toBe(mockGqlNotification1.id);
+		});
+
+		it('should not update a notification if you are not the recipient', async () => {
+			mockDataService.execute.mockResolvedValueOnce({
+				data: {
+					update_app_notification: {
+						returning: [],
+					},
+				},
+			});
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			const { id, created_at, updated_at, ...mockNotification } = mockGqlNotification1;
+			let error;
+			try {
+				await notificationsService.update(id, mockUser.id, mockNotification);
+			} catch (err) {
+				error = err;
+			}
+			expect(error.response).toEqual({
+				statusCode: 404,
+				message: 'Notification not found or you are not the notifications recipient.',
+				error: 'Not Found',
+			});
+		});
+	});
+});

--- a/src/modules/notifications/services/notifications.service.ts
+++ b/src/modules/notifications/services/notifications.service.ts
@@ -1,0 +1,101 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { IPagination, Pagination } from '@studiohyperdrive/pagination';
+import { get } from 'lodash';
+
+import { GqlCreateOrUpdateNotification, GqlNotification, Notification } from '../types';
+
+import {
+	FIND_NOTIFICATIONS_BY_USER,
+	INSERT_NOTIFICATION,
+	UPDATE_NOTIFICATION,
+} from './queries.gql';
+
+import { DataService } from '~modules/data/services/data.service';
+import { PaginationHelper } from '~shared/helpers/pagination';
+
+@Injectable()
+export class NotificationsService {
+	private logger: Logger = new Logger(NotificationsService.name, { timestamp: true });
+
+	constructor(protected dataService: DataService) {}
+
+	/**
+	 * Adapt a notification as returned by a typical graphQl response to our internal notification data model
+	 */
+	public adaptNotification(
+		gqlNotification: GqlNotification | undefined
+	): Notification | undefined {
+		if (!gqlNotification) {
+			return undefined;
+		}
+		return {
+			id: get(gqlNotification, 'id'),
+			description: get(gqlNotification, 'description'),
+			title: get(gqlNotification, 'title'),
+			status: get(gqlNotification, 'status'),
+			visitId: get(gqlNotification, 'visit_id'),
+			createdAt: get(gqlNotification, 'created_at'),
+			updatedAt: get(gqlNotification, 'updated_at'),
+			notificationType: get(gqlNotification, 'notification_type'),
+			showAt: get(gqlNotification, 'show_at'),
+		};
+	}
+
+	public async findNotificationsByUser(
+		userProfileId: string,
+		moreRecentThan: string,
+		page = 1,
+		size = 20
+	): Promise<IPagination<Notification>> {
+		const { offset, limit } = PaginationHelper.convertPagination(page, size);
+		const notificationsResponse = await this.dataService.execute(FIND_NOTIFICATIONS_BY_USER, {
+			userProfileId,
+			moreRecentThan,
+			offset,
+			limit,
+		});
+
+		return Pagination<Notification>({
+			items: notificationsResponse.data.app_notification.map((notification: any) =>
+				this.adaptNotification(notification)
+			),
+			page,
+			size,
+			total: notificationsResponse.data.app_notification_aggregate.aggregate.count,
+		});
+	}
+
+	public async create(
+		notification: Partial<GqlCreateOrUpdateNotification>
+	): Promise<Notification> {
+		const response = await this.dataService.execute(INSERT_NOTIFICATION, {
+			object: notification,
+		});
+		const createdNotification = response?.data?.insert_app_notification?.returning[0];
+		this.logger.debug(`Notification ${createdNotification?.id} created`);
+
+		return this.adaptNotification(createdNotification);
+	}
+
+	public async update(
+		notificationId: string,
+		userProfileId: string,
+		notification: Partial<GqlCreateOrUpdateNotification>
+	): Promise<Notification> {
+		const response = await this.dataService.execute(UPDATE_NOTIFICATION, {
+			notificationId,
+			userProfileId,
+			notification,
+		});
+
+		const updatedNotification = response?.data?.update_app_notification?.returning?.[0];
+		if (!updatedNotification) {
+			throw new NotFoundException(
+				'Notification not found or you are not the notifications recipient.'
+			);
+		}
+		this.logger.debug(`Notification ${updatedNotification.id} updated`);
+
+		return this.adaptNotification(updatedNotification);
+	}
+}

--- a/src/modules/notifications/services/notifications.service.ts
+++ b/src/modules/notifications/services/notifications.service.ts
@@ -88,7 +88,7 @@ export class NotificationsService {
 			notification,
 		});
 
-		const updatedNotification = response?.data?.update_app_notification?.returning?.[0];
+		const updatedNotification = response.data.update_app_notification?.returning?.[0];
 		if (!updatedNotification) {
 			throw new NotFoundException(
 				'Notification not found or you are not the notifications recipient.'

--- a/src/modules/notifications/services/queries.gql.ts
+++ b/src/modules/notifications/services/queries.gql.ts
@@ -1,0 +1,59 @@
+export const FIND_NOTIFICATIONS_BY_USER = `
+	query getNotificationsForUser($userProfileId: uuid, $moreRecentThan: timestamp, $offset: Int, $limit: Int) {
+		app_notification(where: {_or: [{recipient: {_eq: $userProfileId}, show_at: {_gt: $moreRecentThan}, status: {_eq: "READ"}}, {recipient: {_eq: $userProfileId}, status: {_eq: "UNREAD"}}]}, order_by: {show_at: desc, status: asc}, limit: $limit, offset: $offset) {
+			id
+			description
+			title
+			status
+			notification_type
+			recipient
+			visit_id
+			show_at
+			created_at
+			updated_at
+		}
+		app_notification_aggregate(where: {_or: [{recipient: {_eq: $userProfileId}, show_at: {_gt: $moreRecentThan}, status: {_eq: "READ"}}, {recipient: {_eq: $userProfileId}, status: {_eq: "UNREAD"}}]}) {
+			aggregate {
+				count
+			}
+		}
+	}
+`;
+
+export const INSERT_NOTIFICATION = `
+	mutation insertNotification($object: app_notification_insert_input!) {
+		insert_app_notification(objects: [$object]) {
+			returning {
+				id
+				description
+				title
+				status
+				notification_type
+				recipient
+				visit_id
+				show_at
+				created_at
+				updated_at
+			}
+		}
+	}
+`;
+
+export const UPDATE_NOTIFICATION = `
+	mutation updateNotification($notificationId: uuid, $userProfileId: uuid, $notification: app_notification_set_input) {
+		update_app_notification(where: {id: {_eq: $notificationId}, recipient: {_eq: $userProfileId}}, _set: $notification) {
+			returning {
+				id
+				description
+				title
+				status
+				notification_type
+				recipient
+				visit_id
+				show_at
+				created_at
+				updated_at
+			}
+		}
+	}
+`;

--- a/src/modules/notifications/types.ts
+++ b/src/modules/notifications/types.ts
@@ -1,0 +1,49 @@
+export enum NotificationStatus {
+	UNREAD = 'UNREAD',
+	READ = 'READ',
+}
+
+export enum NotificationType {
+	VISIT_REQUEST_APPROVED = 'VISIT_REQUEST_APPROVED',
+	VISIT_REQUEST_DENIED = 'VISIT_REQUEST_DENIED',
+	NEW_VISIT_REQUEST = 'NEW_VISIT_REQUEST',
+	VISIT_REQUEST_CANCELLED = 'VISIT_REQUEST_CANCELLED',
+	START_ACCESS_PERIOD_READING_ROOM = 'START_ACCESS_PERIOD_READING_ROOM',
+}
+
+export interface Notification {
+	description: string;
+	title: string;
+	id: string;
+	status: NotificationStatus;
+	visitId: string;
+	createdAt: string;
+	updatedAt: string;
+	notificationType: string;
+	showAt: string;
+}
+
+export interface GqlNotification {
+	description: string;
+	title: string;
+	id: string;
+	status: NotificationStatus;
+	recipient?: string;
+	visit_id: string;
+	created_at: string;
+	updated_at: string;
+	notification_type: string;
+	show_at: string;
+}
+
+export interface GqlCreateOrUpdateNotification {
+	description: string;
+	title: string;
+	status: NotificationStatus;
+	recipient?: string;
+	visit_id: string;
+	created_at: string;
+	updated_at: string;
+	notification_type: string;
+	show_at: string;
+}


### PR DESCRIPTION
Implements:
* https://meemoo.atlassian.net/browse/ARC-283
* https://meemoo.atlassian.net/browse/ARC-284

![image](https://user-images.githubusercontent.com/1710840/156039123-4db46415-8861-47f8-9e5d-f998b54c85cb.png)

Creating a notification is only implemented in the service, since the proxy will be creating those notification in response to other api calls.