### PR TITLE
feat(arc-430): Move notification construction to notifications service

### DIFF
--- a/src/modules/collections/services/collections.service.spec.ts
+++ b/src/modules/collections/services/collections.service.spec.ts
@@ -122,6 +122,7 @@ const mockCollectionObject: IeObject = {
 	thumbnailUrl:
 		'/viaa/AMSAB/5dc89b7e75e649e191cd86196c255147cd1a0796146d4255acfde239296fa534/keyframes-thumb/keyframes_1_1/keyframe1.jpg',
 	collectionEntryCreatedAt: '2022-02-02T10:55:16.542503',
+	description: 'test description',
 };
 
 const mockUser = {

--- a/src/modules/notifications/controllers/notifications.controller.spec.ts
+++ b/src/modules/notifications/controllers/notifications.controller.spec.ts
@@ -19,7 +19,6 @@ const mockNotification1: Notification = {
 	createdAt: '2022-02-28T17:21:58.937169+00:00',
 	updatedAt: '2022-02-28T17:21:58.937169',
 	type: NotificationType.VISIT_REQUEST_APPROVED,
-	showAt: '2022-02-28T17:29:53.478639',
 	readingRoomId: '52caf5a2-a6d1-4e54-90cc-1b6e5fb66a21',
 };
 
@@ -33,7 +32,6 @@ const mockNotification2: Notification = {
 	createdAt: '2022-02-25T17:21:58.937169+00:00',
 	updatedAt: '2022-02-25T17:21:58.937169',
 	type: NotificationType.VISIT_REQUEST_APPROVED,
-	showAt: '2022-02-25T17:29:53.478639',
 	readingRoomId: '3076ad4b-b86a-49bc-b752-2e1bf34778dc',
 };
 

--- a/src/modules/notifications/services/notifications.service.spec.ts
+++ b/src/modules/notifications/services/notifications.service.spec.ts
@@ -9,7 +9,6 @@ import { Notification, NotificationStatus, NotificationType } from '~modules/not
 import { AudienceType, Space } from '~modules/spaces/types';
 import { User } from '~modules/users/types';
 import { Visit, VisitStatus } from '~modules/visits/types';
-import i18n from '~shared/i18n';
 
 const mockGqlNotification1 = {
 	description:
@@ -60,7 +59,7 @@ const mockNotification: Notification = {
 	createdAt: '2022-02-25T17:21:58.937169+00:00',
 	updatedAt: '2022-02-28T17:54:59.894586',
 	type: NotificationType.VISIT_REQUEST_APPROVED,
-	showAt: '2022-02-25T17:21:58.937169',
+	readingRoomId: '93eedf1a-a508-4657-a942-9d66ed6934c2',
 };
 
 const mockUser: User = {
@@ -152,7 +151,6 @@ describe('NotificationsService', () => {
 			const adapted = notificationsService.adaptNotification(mockGqlNotification);
 			// test some sample keys
 			expect(adapted.id).toEqual(mockGqlNotification.id);
-			expect(adapted.showAt).toEqual(mockGqlNotification.show_at);
 			expect(adapted.type).toEqual(mockGqlNotification.type);
 			expect(adapted.visitId).toEqual(mockGqlNotification.visit_id);
 		});

--- a/src/modules/notifications/services/notifications.service.spec.ts
+++ b/src/modules/notifications/services/notifications.service.spec.ts
@@ -5,7 +5,11 @@ import { NotificationsService } from './notifications.service';
 
 import { DataService } from '~modules/data/services/data.service';
 import { mockGqlNotification } from '~modules/notifications/services/__mocks__/app_notification';
-import { NotificationStatus, NotificationType } from '~modules/notifications/types';
+import { Notification, NotificationStatus, NotificationType } from '~modules/notifications/types';
+import { AudienceType, Space } from '~modules/spaces/types';
+import { User } from '~modules/users/types';
+import { Visit, VisitStatus } from '~modules/visits/types';
+import i18n from '~shared/i18n';
 
 const mockGqlNotification1 = {
 	description:
@@ -46,11 +50,76 @@ const mockGqlNotificationsResult = {
 	},
 };
 
-const mockUser = {
+const mockNotification: Notification = {
+	id: 'bfcae082-2370-4a2b-9f66-a55c869addfb',
+	description:
+		'Je bezoek aanvraag aan de leeszaal van Gents museum is goedgekeurd, je hebt toegang van 12:00 to 16:00 op 17 feb 2022',
+	title: 'Je bezoek aanvraag is goedgekeurd 13',
+	status: NotificationStatus.UNREAD,
+	visitId: '0fb12a25-a882-42f7-9c79-9d77839c7237',
+	createdAt: '2022-02-25T17:21:58.937169+00:00',
+	updatedAt: '2022-02-28T17:54:59.894586',
+	type: NotificationType.VISIT_REQUEST_APPROVED,
+	showAt: '2022-02-25T17:21:58.937169',
+};
+
+const mockUser: User = {
 	id: 'e791ecf1-e121-4c54-9d2e-34524b6467c6',
 	firstName: 'Test',
 	lastName: 'Testers',
 	email: 'test.testers@meemoo.be',
+	acceptedTosAt: '2022-01-24T17:21:58.937169+00:00',
+};
+
+const mockVisit: Visit = {
+	id: '93eedf1a-a508-4657-a942-9d66ed6934c2',
+	spaceId: '3076ad4b-b86a-49bc-b752-2e1bf34778dc',
+	userProfileId: 'df8024f9-ebdc-4f45-8390-72980a3f29f6',
+	timeframe: 'Binnen 3 weken donderdag van 5 to 6',
+	reason: 'Ik wil graag deze zaal bezoeken 7',
+	status: VisitStatus.PENDING,
+	startAt: '2022-03-03T16:00:00',
+	endAt: '2022-03-03T17:00:00',
+	createdAt: '2022-02-11T15:28:40.676',
+	updatedAt: '2022-02-11T15:28:40.676',
+	visitorName: 'Marie Odhiambo',
+	visitorMail: 'marie.odhiambo@example.com',
+	visitorId: 'df8024f9-ebdc-4f45-8390-72980a3f29f6',
+	note: {
+		id: 'a40b8cd7-5973-41ee-8134-c0451ef7fb6a',
+		note: 'test note',
+		createdAt: '2022-01-24T17:21:58.937169+00:00',
+		updatedAt: '2022-01-24T17:21:58.937169+00:00',
+		authorName: 'Test Testers',
+	},
+};
+
+const mockSpace: Space = {
+	id: '52caf5a2-a6d1-4e54-90cc-1b6e5fb66a21',
+	maintainerId: 'OR-154dn75',
+	name: 'Amsab-ISG',
+	description:
+		'Amsab-ISG is het Instituut voor Sociale Geschiedenis. Het bewaart, ontsluit, onderzoekt en valoriseert het erfgoed van sociale en humanitaire bewegingen.',
+	serviceDescription: null,
+	image: null,
+	color: null,
+	logo: 'https://assets.viaa.be/images/OR-154dn75',
+	audienceType: AudienceType.PUBLIC,
+	publicAccess: false,
+	contactInfo: {
+		email: null,
+		telephone: null,
+		address: {
+			street: 'Pijndersstraat 28',
+			postalCode: '9000',
+			locality: 'Gent',
+			postOfficeBoxNumber: null,
+		},
+	},
+	isPublished: false,
+	publishedAt: null,
+	createdAt: '2022-01-13T13:10:14.41978',
+	updatedAt: '2022-01-13T13:10:14.41978',
 };
 
 const mockDataService: Partial<Record<keyof DataService, jest.SpyInstance>> = {
@@ -138,6 +207,58 @@ describe('NotificationsService', () => {
 				[recipient, recipient]
 			);
 			expect(response).toHaveLength(2);
+		});
+	});
+
+	describe('createVisit', () => {
+		it('can send a notification about a visit request creation', async () => {
+			const createForMultipleRecipientsSpy = jest
+				.spyOn(notificationsService, 'createForMultipleRecipients')
+				.mockResolvedValueOnce([mockNotification]);
+
+			const response = await notificationsService.onCreateVisit(
+				mockVisit,
+				[mockUser.id],
+				mockUser
+			);
+
+			expect(response).toHaveLength(1);
+			expect(response[0].status).toEqual(NotificationStatus.UNREAD);
+			createForMultipleRecipientsSpy.mockRestore();
+		});
+	});
+
+	describe('approveVisitRequest', () => {
+		it('can send a notification about a visit request approval', async () => {
+			const createNotificationSpy = jest
+				.spyOn(notificationsService, 'create')
+				.mockResolvedValueOnce(mockNotification);
+
+			const response = await notificationsService.onApproveVisitRequest(
+				mockVisit,
+				mockSpace,
+				mockUser
+			);
+
+			expect(response.status).toEqual(NotificationStatus.UNREAD);
+			createNotificationSpy.mockRestore();
+		});
+	});
+
+	describe('denyVisitRequest', () => {
+		it('can send a notification about a visit request denial', async () => {
+			const createNotificationSpy = jest
+				.spyOn(notificationsService, 'create')
+				.mockResolvedValueOnce(mockNotification);
+
+			const response = await notificationsService.onDenyVisitRequest(
+				mockVisit,
+				mockSpace,
+				mockUser
+			);
+
+			expect(response.status).toEqual(NotificationStatus.UNREAD);
+			createNotificationSpy.mockRestore();
 		});
 	});
 

--- a/src/modules/notifications/services/notifications.service.spec.ts
+++ b/src/modules/notifications/services/notifications.service.spec.ts
@@ -210,8 +210,8 @@ describe('NotificationsService', () => {
 		});
 	});
 
-	describe('createVisit', () => {
-		it('can send a notification about a visit request creation', async () => {
+	describe('onCreateVisit', () => {
+		it('should send a notification about a visit request creation', async () => {
 			const createForMultipleRecipientsSpy = jest
 				.spyOn(notificationsService, 'createForMultipleRecipients')
 				.mockResolvedValueOnce([mockNotification]);
@@ -228,8 +228,8 @@ describe('NotificationsService', () => {
 		});
 	});
 
-	describe('approveVisitRequest', () => {
-		it('can send a notification about a visit request approval', async () => {
+	describe('onApproveVisitRequest', () => {
+		it('should send a notification about a visit request approval', async () => {
 			const createNotificationSpy = jest
 				.spyOn(notificationsService, 'create')
 				.mockResolvedValueOnce(mockNotification);
@@ -245,8 +245,8 @@ describe('NotificationsService', () => {
 		});
 	});
 
-	describe('denyVisitRequest', () => {
-		it('can send a notification about a visit request denial', async () => {
+	describe('onDenyVisitRequest', () => {
+		it('should send a notification about a visit request denial', async () => {
 			const createNotificationSpy = jest
 				.spyOn(notificationsService, 'create')
 				.mockResolvedValueOnce(mockNotification);
@@ -263,7 +263,7 @@ describe('NotificationsService', () => {
 	});
 
 	describe('update', () => {
-		it('can update a notification', async () => {
+		it('should update a notification', async () => {
 			mockDataService.execute.mockResolvedValueOnce({
 				data: {
 					update_app_notification: {

--- a/src/modules/notifications/services/notifications.service.ts
+++ b/src/modules/notifications/services/notifications.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { IPagination, Pagination } from '@studiohyperdrive/pagination';
+import { format } from 'date-fns';
 import { get } from 'lodash';
 
 import {
@@ -7,6 +8,8 @@ import {
 	GqlCreateOrUpdateNotification,
 	GqlNotification,
 	Notification,
+	NotificationStatus,
+	NotificationType,
 } from '../types';
 
 import {
@@ -16,7 +19,11 @@ import {
 } from './queries.gql';
 
 import { DataService } from '~modules/data/services/data.service';
+import { Space } from '~modules/spaces/types';
+import { User } from '~modules/users/types';
+import { Visit } from '~modules/visits/types';
 import { PaginationHelper } from '~shared/helpers/pagination';
+import i18n from '~shared/i18n';
 
 @Injectable()
 export class NotificationsService {
@@ -49,8 +56,8 @@ export class NotificationsService {
 	public async findNotificationsByUser(
 		userProfileId: string,
 		moreRecentThan: string,
-		page = 1,
-		size = 20
+		page,
+		size
 	): Promise<IPagination<Notification>> {
 		const { offset, limit } = PaginationHelper.convertPagination(page, size);
 		const notificationsResponse = await this.dataService.execute(FIND_NOTIFICATIONS_BY_USER, {
@@ -112,7 +119,7 @@ export class NotificationsService {
 			notification,
 		});
 
-		const updatedNotification = response.data.update_app_notification.returning?.[0];
+		const updatedNotification = response.data.update_app_notification.returning[0];
 		if (!updatedNotification) {
 			throw new NotFoundException(
 				'Notification not found or you are not the notifications recipient.'
@@ -121,5 +128,68 @@ export class NotificationsService {
 		this.logger.debug(`Notification ${updatedNotification.id} updated`);
 
 		return this.adaptNotification(updatedNotification);
+	}
+
+	public async onCreateVisit(
+		visit: Visit,
+		recipientIds: string[],
+		user: User
+	): Promise<Notification[]> {
+		return await this.createForMultipleRecipients(
+			{
+				title: i18n.t('Er is aan aanvraag om je leeszaal te bezoeken'),
+				description: i18n.t('{{name}} wil je leeszaal bezoeken', {
+					name: user.firstName + ' ' + user.lastName,
+				}),
+				visit_id: visit.id,
+				type: NotificationType.NEW_VISIT_REQUEST,
+				status: NotificationStatus.UNREAD,
+			},
+			recipientIds
+		);
+	}
+
+	public async onApproveVisitRequest(
+		visit: Visit,
+		space: Space,
+		user: User
+	): Promise<Notification> {
+		return await this.create({
+			title: i18n.t('Je aanvraag voor leeszaal {{name}} is goedgekeurd', {
+				name: space.name,
+			}),
+			description: i18n.t(
+				'Je aanvraag voor leeszaal {{name}} is goedgekeurd. Je zal toegang hebben van {{startDate}} tot {{endDate}}',
+				{
+					name: space.name,
+					startDate: format(new Date(visit.startAt), 'dd/MM/yyyy HH:mm'),
+					endDate: format(new Date(visit.endAt), 'dd/MM/yyyy HH:mm'),
+				}
+			),
+			visit_id: visit.id,
+			type: NotificationType.VISIT_REQUEST_APPROVED,
+			status: NotificationStatus.UNREAD,
+			recipient: user.id,
+		});
+	}
+
+	public async onDenyVisitRequest(
+		visit: Visit,
+		space: Space,
+		user: User,
+		reason?: string
+	): Promise<Notification> {
+		return await this.create({
+			title: i18n.t('Je aanvraag voor leeszaal {{name}} is afgekeurd', {
+				name: space.name,
+			}),
+			description: i18n.t('Reden: {{reason}}', {
+				reason: reason || i18n.t('Er werd geen reden opgegeven'),
+			}),
+			visit_id: visit.id,
+			type: NotificationType.VISIT_REQUEST_DENIED,
+			status: NotificationStatus.UNREAD,
+			recipient: user.id,
+		});
 	}
 }

--- a/src/modules/notifications/services/notifications.service.ts
+++ b/src/modules/notifications/services/notifications.service.ts
@@ -50,7 +50,6 @@ export class NotificationsService {
 			createdAt: get(gqlNotification, 'created_at'),
 			updatedAt: get(gqlNotification, 'updated_at'),
 			type: get(gqlNotification, 'type'),
-			showAt: get(gqlNotification, 'show_at'),
 			readingRoomId: get(gqlNotification, 'visit.cp_space_id'),
 		};
 	}

--- a/src/modules/notifications/types.ts
+++ b/src/modules/notifications/types.ts
@@ -20,7 +20,6 @@ export interface Notification {
 	createdAt: string;
 	updatedAt: string;
 	type: NotificationType;
-	showAt: string;
 	readingRoomId: string;
 }
 

--- a/src/modules/visits/services/visits.service.ts
+++ b/src/modules/visits/services/visits.service.ts
@@ -147,16 +147,10 @@ export class VisitsService {
 			}
 		}
 
-		const {
-			data: { update_cp_visit_by_pk: updatedVisit },
-		} = await this.dataService.execute(UPDATE_VISIT, {
+		await this.dataService.execute(UPDATE_VISIT, {
 			id,
 			updateVisit,
 		});
-
-		if (!updatedVisit) {
-			throw new NotFoundException(`Visit with id '${id}' not found`);
-		}
 
 		if (updateVisitDto.note) {
 			await this.insertNote(id, updateVisitDto.note, userProfileId);

--- a/src/modules/visits/types.ts
+++ b/src/modules/visits/types.ts
@@ -14,7 +14,7 @@ export interface Visit {
 	status: VisitStatus;
 	startAt: string;
 	endAt: string;
-	note: Note;
+	note?: Note;
 	createdAt: string;
 	updatedAt: string;
 	visitorName: string;


### PR DESCRIPTION
```
-------------------------------------------|---------|----------|---------|---------|----------------------------
File                                       | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s          
-------------------------------------------|---------|----------|---------|---------|----------------------------

 src/modules/notifications/controllers     |     100 |      100 |     100 |     100 |                           
  notifications.controller.ts              |     100 |      100 |     100 |     100 |                           
 src/modules/notifications/dto             |      80 |      100 |   33.33 |      75 |                           
  notifications.dto.ts                     |      80 |      100 |   33.33 |      75 | 7,17                      
 src/modules/notifications/services        |     100 |      100 |     100 |     100 |                           
  notifications.service.ts                 |     100 |      100 |     100 |     100 |                           
  queries.gql.ts                           |     100 |      100 |     100 |     100 |                

 src/modules/visits/controllers            |     100 |      100 |     100 |     100 |                           
  visits.controller.ts                     |     100 |      100 |     100 |     100 |                           
 src/modules/visits/dto                    |   79.48 |        0 |   14.28 |   77.14 |                           
  visits.dto.ts                            |   79.48 |        0 |   14.28 |   77.14 | 94,132-135,140,150,160,186
 src/modules/visits/services               |     100 |      100 |     100 |     100 |                           
  queries.gql.ts                           |     100 |      100 |     100 |     100 |                           
  visits.service.ts                        |     100 |      100 |     100 |     100 |             
```