### PR TITLE
feat(arc-535): add permissions for user model

### DIFF
--- a/src/modules/admin/navigations/services/navigations.service.spec.ts
+++ b/src/modules/admin/navigations/services/navigations.service.spec.ts
@@ -15,6 +15,7 @@ const mockUser: User = {
 	lastName: 'Testerom',
 	email: 'test@studiohyperdrive.be',
 	acceptedTosAt: '2022-02-21T14:00:00',
+	permissions: ['CREATE_COLLECTION'],
 };
 
 describe('NavigationsService', () => {

--- a/src/modules/auth/controllers/het-archief.controller.ts
+++ b/src/modules/auth/controllers/het-archief.controller.ts
@@ -93,15 +93,9 @@ export class HetArchiefController {
 
 			SessionHelper.setIdpUserInfo(session, Idp.HETARCHIEF, ldapUser);
 
-			let archiefUser;
-
-			try {
-				archiefUser = await this.usersService.getUserByIdentityId(
-					ldapUser.attributes.entryUUID[0]
-				);
-			} catch (error) {
-				this.logger.log(error);
-			}
+			let archiefUser = await this.usersService.getUserByIdentityId(
+				ldapUser.attributes.entryUUID[0]
+			);
 
 			const userDto = {
 				firstName: ldapUser.attributes.givenName[0],
@@ -125,7 +119,7 @@ export class HetArchiefController {
 					name: i18n.t('modules/collections/controllers___default-collection-name'),
 				});
 			} else {
-				if (!isEqual(omit(archiefUser, ['id']), userDto)) {
+				if (!isEqual(omit(archiefUser, ['id', 'permissions']), userDto)) {
 					// update user
 					this.logger.debug(`User ${ldapUser.attributes.mail[0]} must be updated`);
 					archiefUser = await this.usersService.updateUser(archiefUser.id, userDto);

--- a/src/modules/auth/controllers/meemoo.controller.ts
+++ b/src/modules/auth/controllers/meemoo.controller.ts
@@ -117,7 +117,7 @@ export class MeemooController {
 					name: i18n.t('modules/collections/controllers___default-collection-name'),
 				});
 			} else {
-				if (!isEqual(omit(archiefUser, ['id']), userDto)) {
+				if (!isEqual(omit(archiefUser, ['id', 'permissions']), userDto)) {
 					// update user
 					this.logger.debug(`User ${ldapUser.attributes.mail[0]} must be updated`);
 					archiefUser = await this.usersService.updateUser(archiefUser.id, userDto);

--- a/src/modules/collections/controllers/collections.controller.spec.ts
+++ b/src/modules/collections/controllers/collections.controller.spec.ts
@@ -59,6 +59,7 @@ const mockUser: User = {
 	lastName: 'Testers',
 	email: 'test.testers@meemoo.be',
 	acceptedTosAt: '1997-01-01T00:00:00.000Z',
+	permissions: ['CREATE_COLLECTION'],
 };
 
 const mockCollectionsService: Partial<Record<keyof CollectionsService, jest.SpyInstance>> = {

--- a/src/modules/notifications/controllers/notifications.controller.spec.ts
+++ b/src/modules/notifications/controllers/notifications.controller.spec.ts
@@ -51,6 +51,7 @@ const mockUser: User = {
 	lastName: 'Testers',
 	email: 'test.testers@meemoo.be',
 	acceptedTosAt: '1997-01-01T00:00:00.000Z',
+	permissions: ['CREATE_COLLECTION'],
 };
 
 const mockNotificationsService: Partial<Record<keyof NotificationsService, jest.SpyInstance>> = {

--- a/src/modules/notifications/services/notifications.service.spec.ts
+++ b/src/modules/notifications/services/notifications.service.spec.ts
@@ -68,6 +68,7 @@ const mockUser: User = {
 	lastName: 'Testers',
 	email: 'test.testers@meemoo.be',
 	acceptedTosAt: '2022-01-24T17:21:58.937169+00:00',
+	permissions: ['CREATE_COLLECTION'],
 };
 
 const mockVisit: Visit = {

--- a/src/modules/users/services/queries.gql.ts
+++ b/src/modules/users/services/queries.gql.ts
@@ -6,6 +6,13 @@ export const GET_USER_BY_IDENTITY_ID = `
 			last_name
 			mail
 			accepted_tos_at
+			group {
+				permissions {
+					permission {
+						name
+					}
+				}
+			}
 		}
 	}
 `;
@@ -18,6 +25,13 @@ export const INSERT_USER = `
 			last_name
 			mail
 			accepted_tos_at
+			group {
+				permissions {
+					permission {
+						name
+					}
+				}
+			}
 		}
 	}
 `;
@@ -38,6 +52,13 @@ export const UPDATE_USER = `
 			last_name
 			mail
 			accepted_tos_at
+			group {
+				permissions {
+					permission {
+						name
+					}
+				}
+			}
 		}
 	}
 `;

--- a/src/modules/users/services/users.service.spec.ts
+++ b/src/modules/users/services/users.service.spec.ts
@@ -15,6 +15,15 @@ const graphQlUserResponse = {
 	last_name: 'Testerom',
 	mail: 'test@studiohypderdrive.be',
 	accepted_tos_at: '2022-02-21T14:00:00',
+	group: {
+		permissions: [
+			{
+				permission: {
+					name: 'CREATE_COLLECTION',
+				},
+			},
+		],
+	},
 };
 
 const archiefUser = {
@@ -23,6 +32,7 @@ const archiefUser = {
 	lastName: 'Testerom',
 	email: 'test@studiohypderdrive.be',
 	acceptedTosAt: '2022-02-21T14:00:00',
+	permissions: ['CREATE_COLLECTION'],
 };
 
 describe('UsersService', () => {

--- a/src/modules/users/services/users.service.ts
+++ b/src/modules/users/services/users.service.ts
@@ -1,8 +1,8 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { get } from 'lodash';
 
 import { CreateUserDto, UpdateAcceptedTosDto, UpdateUserDto } from '../dto/users.dto';
-import { User } from '../types';
+import { GqlPermissionData, User } from '../types';
 
 import {
 	GET_USER_BY_IDENTITY_ID,
@@ -27,6 +27,9 @@ export class UsersService {
 			lastName: get(graphQlUser, 'last_name'),
 			email: get(graphQlUser, 'mail'),
 			acceptedTosAt: get(graphQlUser, 'accepted_tos_at'),
+			permissions: get(graphQlUser, 'group.permissions', []).map(
+				(permData: GqlPermissionData) => permData.permission.name
+			),
 		};
 	}
 

--- a/src/modules/users/types.ts
+++ b/src/modules/users/types.ts
@@ -4,4 +4,13 @@ export interface User {
 	lastName: string;
 	email: string;
 	acceptedTosAt: string;
+	permissions: string[];
+}
+
+export interface GqlPermission {
+	name: string;
+}
+
+export interface GqlPermissionData {
+	permission: GqlPermission;
 }

--- a/src/modules/visits/controllers/visits.controller.spec.ts
+++ b/src/modules/visits/controllers/visits.controller.spec.ts
@@ -54,6 +54,7 @@ const mockUser: User = {
 	lastName: 'Testers',
 	email: 'test.testers@meemoo.be',
 	acceptedTosAt: '1997-01-01T00:00:00.000Z',
+	permissions: ['CREATE_COLLECTION'],
 };
 
 const mockSpace: Space = {

--- a/src/shared/auth/session-helper.spec.ts
+++ b/src/shared/auth/session-helper.spec.ts
@@ -30,6 +30,7 @@ const mockArchiefUser = {
 	lastName: 'Testerom',
 	email: 'test@studiohyperdrive.be',
 	acceptedTosAt: '2022-02-21T14:00:00',
+	permissions: ['CREATE_COLLECTION'],
 };
 
 describe('SessionHelper', () => {


### PR DESCRIPTION
return permissions in check-login
- Requires PR for Hasura: https://github.com/viaacode/hetarchief-hasura/pull/67
- Assumes the user.profile is linked to a (user)group in the DB
![CleanShot 2022-03-08 at 09 26 53](https://user-images.githubusercontent.com/8707395/157197007-3fd516d8-947f-4fea-b896-c141900357e1.png)
![CleanShot 2022-03-08 at 09 28 23](https://user-images.githubusercontent.com/8707395/157197321-deebd231-4e4d-48bd-ab15-e9f092c9ca5e.png)

