### PR TITLE
fix(arc-300): updated media object detail with latest db model

### DIFF
--- a/src/modules/media/services/__mocks__/object_ie.ts
+++ b/src/modules/media/services/__mocks__/object_ie.ts
@@ -75,6 +75,33 @@ export default {
 					'49b1bf8894004fd49aeaba36cfc5a958d5c32a4566244999a862e80b498a2c7c',
 				schema_date_created: '[2020-09-01,)',
 				schema_date_created_lower_bound: '2020-09-01',
+				premis_is_represented_by: [
+					{
+						schema_name: 'Durf te vragen R002 A0001',
+						schema_alternate_name: 'Durf te vragen R002 A0001',
+						schema_description: null,
+						ie_meemoo_fragment_id:
+							'49b1bf8894004fd49aeaba36cfc5a958d5c32a4566244999a862e80b498a2c7c7bee152896204294938534fc7f3c6793',
+						dcterms_format: 'mp4',
+						schema_transcript: null,
+						schema_date_created: null,
+						id: '49b1bf8894004fd49aeaba36cfc5a958d5c32a4566244999a862e80b498a2c7c7bee152896204294938534fc7f3c6793/mp4_vrt',
+						premis_includes: [
+							{
+								id: 'https://archief-media.viaa.be/viaa/VRT/49b1bf8894004fd49aeaba36cfc5a958d5c32a4566244999a862e80b498a2c7c/browse.mp4',
+								schema_name: 'browse.mp4',
+								schema_alternate_name: '8911p09j1g.MXF',
+								schema_description: null,
+								representation_id:
+									'49b1bf8894004fd49aeaba36cfc5a958d5c32a4566244999a862e80b498a2c7c7bee152896204294938534fc7f3c6793/mp4_vrt',
+								ebucore_media_type: 'mp4',
+								ebucore_is_media_fragment_of: null,
+								schema_embed_url:
+									'VRT/49b1bf8894004fd49aeaba36cfc5a958d5c32a4566244999a862e80b498a2c7c/browse.mp4',
+							},
+						],
+					},
+				],
 			},
 		],
 	},

--- a/src/modules/media/services/media.service.spec.ts
+++ b/src/modules/media/services/media.service.spec.ts
@@ -123,6 +123,28 @@ describe('MediaService', () => {
 			expect(response.keywords.length).toBeGreaterThan(10);
 		});
 
+		it('returns an empty array if no representations were found', async () => {
+			const originalReps = objectIe.data.object_ie[0].premis_is_represented_by;
+			objectIe.data.object_ie[0].premis_is_represented_by = null;
+			mockDataService.execute.mockResolvedValueOnce(objectIe);
+			const response = await mediaService.findById(mockObjectId);
+			expect(response.id).toEqual(mockObjectId);
+			expect(response.representations).toEqual([]);
+			//reset
+			objectIe.data.object_ie[0].premis_is_represented_by = originalReps;
+		});
+
+		it('returns an empty array if no files were found', async () => {
+			const originalFiles =
+				objectIe.data.object_ie[0].premis_is_represented_by[0].premis_includes;
+			objectIe.data.object_ie[0].premis_is_represented_by[0].premis_includes = null;
+			mockDataService.execute.mockResolvedValueOnce(objectIe);
+			const response = await mediaService.findById(mockObjectId);
+			expect(response.id).toEqual(mockObjectId);
+			expect(response.representations[0].files).toEqual([]);
+			//reset
+			objectIe.data.object_ie[0].premis_is_represented_by[0].premis_includes = originalFiles;
+		});
 		it('throws a notfoundexception if the object was not found', async () => {
 			mockDataService.execute.mockResolvedValueOnce({
 				data: {
@@ -146,7 +168,7 @@ describe('MediaService', () => {
 	describe('getPlayableUrl', () => {
 		it('returns a playable url', async () => {
 			mockDataService.execute.mockResolvedValueOnce({
-				data: { object_ie_by_pk: { schema_embed_url: '/vrt/item-1' } },
+				data: { object_file: [{ schema_embed_url: 'vrt/item-1' }] },
 			});
 			nock('http://ticketservice/')
 				.get('/vrt/item-1')
@@ -158,12 +180,12 @@ describe('MediaService', () => {
 
 		it('uses the fallback referer if none was set', async () => {
 			mockDataService.execute.mockResolvedValueOnce({
-				data: { object_ie_by_pk: { schema_embed_url: '/vrt/item-1' } },
+				data: { object_file: [{ schema_embed_url: 'vrt/item-1' }] },
 			});
 			nock('http://ticketservice/')
 				.get('/vrt/item-1')
 				.query({
-					app: 'OR-avo2',
+					app: 'OR-*',
 					client: '',
 					referer: 'host',
 					maxage: 'ticketServiceMaxAge',
@@ -177,16 +199,16 @@ describe('MediaService', () => {
 	describe('getEmbedUrl', () => {
 		it('returns the embedUrl for an item', async () => {
 			mockDataService.execute.mockResolvedValueOnce({
-				data: { object_ie_by_pk: { schema_embed_url: '/vrt/item-1' } },
+				data: { object_file: [{ schema_embed_url: 'vrt/item-1' }] },
 			});
 			const url = await mediaService.getEmbedUrl('vrt-id');
-			expect(url).toEqual('/vrt/item-1');
+			expect(url).toEqual('vrt/item-1');
 		});
 
 		it('throws a notfoundexception if the item was not found', async () => {
 			mockDataService.execute.mockResolvedValueOnce({
 				data: {
-					object_ie_by_pk: null,
+					object_file: [],
 				},
 			});
 			let error;

--- a/src/modules/media/services/media.service.ts
+++ b/src/modules/media/services/media.service.ts
@@ -1,13 +1,13 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import got, { Got } from 'got';
-import { get, trimStart } from 'lodash';
+import { get, isEmpty, trimStart } from 'lodash';
 
 import { MediaQueryDto } from '../dto/media.dto';
 import { QueryBuilder } from '../elasticsearch/queryBuilder';
-import { Media, PlayerTicket } from '../types';
+import { Media, PlayerTicket, Representation } from '../types';
 
-import { GET_OBJECT_IE_BY_ID, GET_OBJECT_IE_PLAY_INFO_BY_ID } from './queries.gql';
+import { GET_FILE_BY_REPRESENTATION_ID, GET_OBJECT_IE_BY_ID } from './queries.gql';
 
 import { DataService } from '~modules/data/services/data.service';
 
@@ -105,7 +105,41 @@ export class MediaService {
 			dateCreatedLowerBound: get(graphQlObject, 'schema_date_created_lower_bound'),
 			genre: get(graphQlObject, 'schema_genre'),
 			ebucoreObjectType: get(graphQlObject, 'ebucore_object_type'),
+			representations: this.adaptRepresentations(graphQlObject.premis_is_represented_by),
 		};
+	}
+
+	public adaptRepresentations(graphQlRepresentations: any): Representation[] {
+		if (isEmpty(graphQlRepresentations)) {
+			return [];
+		}
+		return graphQlRepresentations.map((representation) => ({
+			name: get(representation, 'schema_name'),
+			alternateName: get(representation, 'schema_alternate_name'),
+			description: get(representation, 'schema_description'),
+			meemooFragmentId: get(representation, 'ie_meemoo_fragment_id'),
+			dctermsFormat: get(representation, 'dcterms_format'),
+			transcript: get(representation, 'schema_transcript'),
+			dateCreated: get(representation, 'schema_date_created'),
+			id: get(representation, 'id'),
+			files: this.adaptFiles(representation.premis_includes),
+		}));
+	}
+
+	public adaptFiles(graphQlFiles: any): File[] {
+		if (isEmpty(graphQlFiles)) {
+			return [];
+		}
+		return graphQlFiles.map((file) => ({
+			id: get(file, 'id'),
+			name: get(file, 'schema_name'),
+			alternateName: get(file, 'schema_alternate_name'),
+			description: get(file, 'schema_description'),
+			representationId: get(file, 'representation_id'),
+			ebucoreMediaType: get(file, 'ebucore_media_type'),
+			ebucoreIsMediaFragmentOf: get(file, 'ebucore_is_media_fragment_of'),
+			embedUrl: get(file, 'schema_embed_url'),
+		}));
 	}
 
 	public getSearchEndpoint(esIndex: string): string {
@@ -155,11 +189,11 @@ export class MediaService {
 	}
 
 	public async getPlayableUrl(id: string, referer: string): Promise<string> {
-		const embedUrl = trimStart(await this.getEmbedUrl(id), '/');
+		const embedUrl = await this.getEmbedUrl(id);
 
 		const data = {
-			app: 'OR-avo2',
-			client: '', // TODO Required? -- SEE ARC-536
+			app: 'OR-*',
+			client: '', // Asked in ARC-536
 			referer: referer || this.host,
 			maxage: this.ticketServiceMaxAge,
 		};
@@ -177,12 +211,12 @@ export class MediaService {
 
 	public async getEmbedUrl(id: string): Promise<string> {
 		const {
-			data: { object_ie_by_pk: objectIe },
-		} = await this.dataService.execute(GET_OBJECT_IE_PLAY_INFO_BY_ID, { id });
-		if (!objectIe) {
+			data: { object_file: objectFile },
+		} = await this.dataService.execute(GET_FILE_BY_REPRESENTATION_ID, { id });
+		if (!objectFile[0]) {
 			throw new NotFoundException(`Object IE with id '${id}' not found`);
 		}
 
-		return objectIe.schema_embed_url;
+		return objectFile[0].schema_embed_url;
 	}
 }

--- a/src/modules/media/services/queries.gql.ts
+++ b/src/modules/media/services/queries.gql.ts
@@ -1,8 +1,14 @@
-export const GET_OBJECT_IE_PLAY_INFO_BY_ID = `
-	query playableUrl($id: String!) {
-		object_ie_by_pk(schema_identifier: $id) {
-		schema_identifier
-		schema_embed_url
+export const GET_FILE_BY_REPRESENTATION_ID = `
+	query getFileByRepresentationId($id: String) {
+		object_file(where: {representation_id: {_eq: $id } }) {
+			id
+			schema_name
+			schema_alternate_name
+			schema_description
+			representation_id
+			ebucore_media_type
+			ebucore_is_media_fragment_of
+			schema_embed_url
 		}
 	}
 `;
@@ -60,6 +66,26 @@ export const GET_OBJECT_IE_BY_ID = `
 			schema_date_created_lower_bound
 			ebucore_object_type
 			schema_genre
+			premis_is_represented_by {
+				schema_name
+				schema_alternate_name
+				schema_description
+				ie_meemoo_fragment_id
+				dcterms_format
+				schema_transcript
+				schema_date_created
+				id
+				premis_includes {
+					id
+					schema_name
+					schema_alternate_name
+					schema_description
+					representation_id
+					ebucore_media_type
+					ebucore_is_media_fragment_of
+					schema_embed_url
+				}
+			}
 		}
   	}
 `;

--- a/src/modules/media/types.ts
+++ b/src/modules/media/types.ts
@@ -34,6 +34,49 @@ export interface PlayerTicket {
 	};
 }
 
+/**
+ * premis_is_represented_by {
+      schema_name
+      schema_alternate_name
+      schema_description
+      ie_meemoo_fragment_id
+      dcterms_format
+      schema_transcript
+      schema_date_created
+      id
+      premis_includes {
+        id
+        schema_name
+        schema_alternate_name
+        schema_description
+        representation_id
+        ebucore_media_type
+        ebucore_is_media_fragment_of
+        schema_embed_url
+      }
+ */
+export interface File {
+	id: string;
+	name: string;
+	alternateName: string;
+	description: string;
+	representationId: string;
+	ebucoreMediaType: string;
+	ebucoreIsMediaFragmentOf: string;
+	embedUrl: string;
+}
+export interface Representation {
+	name: string;
+	alternateName: string;
+	description: string;
+	meemooFragmentId: string;
+	dctermsFormat: string;
+	transcript: string;
+	dateCreated: string;
+	id: string;
+	files: File[];
+}
+
 export interface Media {
 	id: string;
 	premisIdentifier: any;
@@ -74,4 +117,5 @@ export interface Media {
 	dateCreated: string;
 	dateCreatedLowerBound: string;
 	ebucoreObjectType: string;
+	representations: Representation[];
 }


### PR DESCRIPTION
GET media/:id now returns the full db structure with representations and files

player ticket now requires representationId to get a playable url
![CleanShot 2022-03-09 at 14 48 24](https://user-images.githubusercontent.com/8707395/157454783-5a3a7bca-551b-4780-bbea-be351404ed59.png)
![CleanShot 2022-03-09 at 14 50 57](https://user-images.githubusercontent.com/8707395/157454935-d2344e46-71f2-4dd0-aa96-0ce5fabd5b84.png)

