### PR TITLE
fix(collections): fix issue with schema identifier vs meemoo fragment id

### DIFF
--- a/src/modules/collections/controllers/collections.controller.spec.ts
+++ b/src/modules/collections/controllers/collections.controller.spec.ts
@@ -65,7 +65,7 @@ const mockUser: User = {
 const mockCollectionsService: Partial<Record<keyof CollectionsService, jest.SpyInstance>> = {
 	findCollectionsByUser: jest.fn(),
 	findCollectionById: jest.fn(),
-	findObjectInCollection: jest.fn(),
+	findObjectInCollectionBySchemaIdentifier: jest.fn(),
 	findObjectsByCollectionId: jest.fn(),
 	create: jest.fn(),
 	update: jest.fn(),
@@ -278,7 +278,7 @@ describe('CollectionsController', () => {
 			mockCollectionsService.findCollectionById.mockResolvedValue(
 				mockCollectionsResponse.items[0]
 			);
-			mockCollectionsService.findObjectInCollection.mockResolvedValue(null);
+			mockCollectionsService.findObjectInCollectionBySchemaIdentifier.mockResolvedValue(null);
 
 			const collectionObject = await collectionsController.moveObjectToAnotherCollection(
 				mockCollectionsResponse.items[0].id,
@@ -300,7 +300,7 @@ describe('CollectionsController', () => {
 					userProfileId: 'not-the-owner-id',
 				})
 				.mockResolvedValue(mockCollectionsResponse.items[0]);
-			mockCollectionsService.findObjectInCollection.mockResolvedValue(null);
+			mockCollectionsService.findObjectInCollectionBySchemaIdentifier.mockResolvedValue(null);
 
 			let error;
 			try {
@@ -327,7 +327,7 @@ describe('CollectionsController', () => {
 					...mockCollectionsResponse.items[0],
 					userProfileId: 'not-the-owner-id',
 				});
-			mockCollectionsService.findObjectInCollection.mockResolvedValue(null);
+			mockCollectionsService.findObjectInCollectionBySchemaIdentifier.mockResolvedValue(null);
 
 			let error;
 			try {

--- a/src/modules/collections/controllers/collections.controller.ts
+++ b/src/modules/collections/controllers/collections.controller.ts
@@ -108,7 +108,7 @@ export class CollectionsController {
 	@Post(':collectionId/objects/:objectId')
 	public async addObjectToCollection(
 		@Param('collectionId') collectionId: string,
-		@Param('objectId') objectId: string,
+		@Param('objectId') objectSchemaIdentifier: string,
 		@Session() session: Record<string, any>
 	): Promise<IeObject> {
 		const collection = await this.collectionsService.findCollectionById(collectionId);
@@ -116,9 +116,10 @@ export class CollectionsController {
 		if (collection.userProfileId !== user.id) {
 			throw new UnauthorizedException('You can only add objects to your own collections');
 		}
+
 		const collectionObject = await this.collectionsService.addObjectToCollection(
 			collectionId,
-			objectId
+			objectSchemaIdentifier
 		);
 		return collectionObject;
 	}
@@ -151,7 +152,7 @@ export class CollectionsController {
 	@Patch(':oldCollectionId/objects/:objectId/move')
 	public async moveObjectToAnotherCollection(
 		@Param('oldCollectionId') oldCollectionId: string,
-		@Param('objectId') objectId: string,
+		@Param('objectId') objectSchemaIdentifier: string,
 		@Query('newCollectionId') newCollectionId: string,
 		@Session() session: Record<string, any>
 	): Promise<IeObject> {
@@ -170,11 +171,11 @@ export class CollectionsController {
 
 		const collectionObject = await this.collectionsService.addObjectToCollection(
 			newCollectionId,
-			objectId
+			objectSchemaIdentifier
 		);
 		await this.collectionsService.removeObjectFromCollection(
 			oldCollectionId,
-			objectId,
+			objectSchemaIdentifier,
 			user.id
 		);
 		return collectionObject;

--- a/src/modules/collections/services/__mocks__/users_collection.ts
+++ b/src/modules/collections/services/__mocks__/users_collection.ts
@@ -19,6 +19,8 @@ export const mockGqlCollection: GqlCollection = {
 				schema_number_of_pages: null,
 				schema_creator: null,
 				schema_identifier: '8s4jm2514q',
+				meemoo_fragment_id:
+					'ec124bb2bd7b43a8b3dec94bd6567fec3f723d4c91cb418ba6eb26ded1ca1ef04b9ddbc8e98149858cc58dfebad3e6f5',
 				maintainer: {
 					schema_identifier: 'OR-1v5bc86',
 					schema_name: 'Huis van Alijn',

--- a/src/modules/collections/services/collections.service.spec.ts
+++ b/src/modules/collections/services/collections.service.spec.ts
@@ -37,6 +37,8 @@ const mockGqlCollectionObject: GqlObject = {
 	dcterms_format: 'video',
 	schema_number_of_pages: null,
 	schema_identifier: '8s4jm2514q',
+	meemoo_fragment_id:
+		'ec124bb2bd7b43a8b3dec94bd6567fec3f723d4c91cb418ba6eb26ded1ca1ef04b9ddbc8e98149858cc58dfebad3e6f5',
 	maintainer: {
 		schema_identifier: 'OR-1v5bc86',
 		schema_name: 'Huis van Alijn',
@@ -121,6 +123,8 @@ const mockGqlCollectionObjectResult = {
 
 const mockCollectionObject: IeObject = {
 	id: '8s4jm2514q',
+	meemooFragmentId:
+		'ec124bb2bd7b43a8b3dec94bd6567fec3f723d4c91cb418ba6eb26ded1ca1ef04b9ddbc8e98149858cc58dfebad3e6f5',
 	name: 'CGSO. De mannenbeweging - mannenemancipatie - 1982',
 	termsAvailable: '2015-09-19T12:08:24',
 	creator: null,
@@ -274,7 +278,7 @@ describe('CollectionsService', () => {
 	describe('findObjectInCollection', () => {
 		it('returns one objects in a collection', async () => {
 			mockDataService.execute.mockResolvedValueOnce(mockGqlCollectionObjectResult);
-			const response = await collectionsService.findObjectInCollection(
+			const response = await collectionsService.findObjectInCollectionBySchemaIdentifier(
 				mockGqlCollection1.id,
 				mockCollectionObject.id
 			);
@@ -346,7 +350,7 @@ describe('CollectionsService', () => {
 	describe('addObjectToCollection', () => {
 		it('can add object to a collection', async () => {
 			const findObjectInCollectionSpy = jest
-				.spyOn(collectionsService, 'findObjectInCollection')
+				.spyOn(collectionsService, 'findObjectInCollectionBySchemaIdentifier')
 				.mockResolvedValueOnce(null);
 			mockDataService.execute.mockResolvedValueOnce({
 				data: {
@@ -366,7 +370,7 @@ describe('CollectionsService', () => {
 
 		it('can not add object to a collection if it already exists', async () => {
 			const findObjectInCollectionSpy = jest
-				.spyOn(collectionsService, 'findObjectInCollection')
+				.spyOn(collectionsService, 'findObjectInCollectionBySchemaIdentifier')
 				.mockResolvedValueOnce(mockCollectionObject);
 
 			let error;

--- a/src/modules/collections/services/queries.gql.ts
+++ b/src/modules/collections/services/queries.gql.ts
@@ -103,8 +103,8 @@ export const DELETE_COLLECTION = `
 `;
 
 export const FIND_OBJECT_IN_COLLECTION = `
-	query findObjectInCollection($collectionId: uuid, $objectId: String) {
-		users_collection_ie(where: {user_collection_id: {_eq: $collectionId}, object_ie_schema_identifier: {_eq: $objectId}}) {
+	query findObjectInCollection($collectionId: uuid, $objectSchemaIdentifier: String) {
+		users_collection_ie(where: {user_collection_id: {_eq: $collectionId}, object_ie_schema_identifier: {_eq: $objectSchemaIdentifier}}) {
 			ie {
 				schema_name
 				schema_creator
@@ -113,15 +113,38 @@ export const FIND_OBJECT_IN_COLLECTION = `
 				dcterms_format
 				schema_number_of_pages
 				schema_identifier
+				meemoo_fragment_id
 			}
 			created_at
 		}
 	}
 `;
 
+export const FIND_OBJECT_BY_FRAGMENT_IDENTIFIER = `
+	query getObjectBySchemaIdentifier($objectSchemaIdentifier: String) {
+		object_ie(where: {schema_identifier: {_eq: $objectSchemaIdentifier}}, limit: 1) {
+			schema_name
+			schema_creator
+			dcterms_available
+			schema_thumbnail_url
+			dcterms_format
+			schema_number_of_pages
+			schema_identifier
+			meemoo_fragment_id
+			maintainer {
+				schema_identifier
+				schema_name
+				space {
+					id
+				}
+			}
+		}
+	}
+`;
+
 export const INSERT_OBJECT_INTO_COLLECTION = `
-	mutation insertObjectIntoCollection($collectionId: uuid, $objectId: String) {
-		insert_users_collection_ie(objects: {user_collection_id: $collectionId, object_ie_schema_identifier: $objectId}) {
+	mutation insertObjectIntoCollection($collectionId: uuid, $objectSchemaIdentifier: String, $objectMeemooFragmentId: String) {
+		insert_users_collection_ie(objects: {user_collection_id: $collectionId, object_ie_schema_identifier: $objectSchemaIdentifier, object_ie_meemoo_fragment_id: $objectMeemooFragmentId}) {
 			returning {
 				created_at
 				ie {
@@ -140,8 +163,8 @@ export const INSERT_OBJECT_INTO_COLLECTION = `
 `;
 
 export const REMOVE_OBJECT_FROM_COLLECTION = `
-	mutation removeObjectFromCollection($objectId: String, $collectionId: uuid, $userProfileId: uuid) {
-		delete_users_collection_ie(where: {object_ie_schema_identifier: {_eq: $objectId}, user_collection_id: {_eq: $collectionId}, collection: {user_profile_id: {_eq: $userProfileId}}}) {
+	mutation removeObjectFromCollection($objectSchemaIdentifier: String, $collectionId: uuid, $userProfileId: uuid) {
+		delete_users_collection_ie(where: {object_ie_schema_identifier: {_eq: $objectSchemaIdentifier}, user_collection_id: {_eq: $collectionId}, collection: {user_profile_id: {_eq: $userProfileId}}}) {
 			affected_rows
 		}
 	}

--- a/src/modules/collections/types.ts
+++ b/src/modules/collections/types.ts
@@ -47,6 +47,7 @@ export interface GqlObject {
 	dcterms_format: string;
 	schema_number_of_pages: any;
 	schema_identifier: string;
+	meemoo_fragment_id: string;
 	maintainer: {
 		schema_identifier: string;
 		schema_name: string;
@@ -57,11 +58,12 @@ export interface GqlObject {
 }
 
 export interface IeObject {
-	collectionEntryCreatedAt: string;
+	collectionEntryCreatedAt?: string;
 	creator: any;
 	description: string;
 	format: string;
 	id: string;
+	meemooFragmentId: string;
 	name: string;
 	numberOfPages: any;
 	termsAvailable: string;

--- a/src/modules/media/services/media.service.ts
+++ b/src/modules/media/services/media.service.ts
@@ -45,7 +45,8 @@ export class MediaService {
 
 	public adapt(graphQlObject: any): Media {
 		return {
-			id: get(graphQlObject, 'schema_identifier'),
+			id: get(graphQlObject, 'meemoo_fragment_id'),
+			schemaIdentifier: get(graphQlObject, 'schema_identifier'),
 			premisIdentifier: get(graphQlObject, 'premis_identifier'),
 			premisRelationship: get(graphQlObject, 'premis_relationship'),
 			isPartOf: get(graphQlObject, 'schema_is_part_of'),

--- a/src/modules/media/services/queries.gql.ts
+++ b/src/modules/media/services/queries.gql.ts
@@ -16,6 +16,7 @@ export const GET_FILE_BY_REPRESENTATION_ID = `
 export const GET_OBJECT_IE_BY_ID = `
 	query objectDetail($id: String!) {
 		object_ie(where: { schema_identifier: { _eq: $id } }) {
+			meemoo_fragment_id
 			schema_identifier
 			premis_identifier
 			premis_relationship
@@ -60,7 +61,6 @@ export const GET_OBJECT_IE_BY_ID = `
 			schema_alternate_name
 			schema_duration
 			schema_license
-			meemoo_fragment_id
 			meemoo_media_object_id
 			schema_date_created
 			schema_date_created_lower_bound

--- a/src/modules/media/types.ts
+++ b/src/modules/media/types.ts
@@ -79,6 +79,7 @@ export interface Representation {
 
 export interface Media {
 	id: string;
+	schemaIdentifier: string;
 	premisIdentifier: any;
 	premisRelationship: string;
 	isPartOf: string;


### PR DESCRIPTION
When you add an object to a collection the client will pass the schema_identifier id
the backend will resolve this id to the meemoo_fragment_id
and then insert the collection_ie object with both ids

Still some issues where elasticsearch contains items that do not seem to be present in the postgres database.

![image](https://user-images.githubusercontent.com/1710840/157507039-6ab0d804-0f51-4570-be66-037b46c56f92.png)
