### PR TITLE
feat(arc-486): get active visit for user and space

### DIFF
--- a/src/modules/visits/controllers/visits.controller.spec.ts
+++ b/src/modules/visits/controllers/visits.controller.spec.ts
@@ -100,6 +100,7 @@ const mockVisitsService: Partial<Record<keyof VisitsService, jest.SpyInstance>> 
 	findById: jest.fn(),
 	create: jest.fn(),
 	update: jest.fn(),
+	getActiveVisitForUserAndSpace: jest.fn(),
 };
 
 const mockNotificationsService: Partial<Record<keyof NotificationsService, jest.SpyInstance>> = {
@@ -163,6 +164,16 @@ describe('VisitsController', () => {
 		it('should return a visit by id', async () => {
 			mockVisitsService.findById.mockResolvedValueOnce(mockVisit1);
 			const visit = await visitsController.getVisitById('1');
+			expect(visit).toEqual(mockVisit1);
+		});
+	});
+
+	describe('getActiveVisitForUserAndSpace', () => {
+		it('should return the active visit for the current user', async () => {
+			mockVisitsService.getActiveVisitForUserAndSpace.mockResolvedValueOnce(mockVisit1);
+			const visit = await visitsController.getActiveVisitForUserAndSpace('space-1', {
+				archiefUserInfo: { id: 'user-1' },
+			});
 			expect(visit).toEqual(mockVisit1);
 		});
 	});

--- a/src/modules/visits/controllers/visits.controller.ts
+++ b/src/modules/visits/controllers/visits.controller.ts
@@ -48,7 +48,7 @@ export class VisitsController {
 		return visit;
 	}
 
-	@Get(':spaceId/active')
+	@Get('active-for-space/:spaceId')
 	public async getActiveVisitForUserAndSpace(
 		@Param('spaceId') spaceId: string,
 		@Session() session: Record<string, any>

--- a/src/modules/visits/controllers/visits.controller.ts
+++ b/src/modules/visits/controllers/visits.controller.ts
@@ -48,10 +48,22 @@ export class VisitsController {
 		return visit;
 	}
 
+	@Get(':spaceId/active')
+	public async getActiveVisitForUserAndSpace(
+		@Param('spaceId') spaceId: string,
+		@Session() session: Record<string, any>
+	): Promise<Visit | null> {
+		const activeVisit = await this.visitsService.getActiveVisitForUserAndSpace(
+			SessionHelper.getArchiefUserInfo(session).id,
+			spaceId
+		);
+		return activeVisit;
+	}
+
 	@Post()
 	public async createVisit(
 		@Body() createVisitDto: CreateVisitDto,
-		@Session() session
+		@Session() session: Record<string, any>
 	): Promise<Visit> {
 		if (!createVisitDto.acceptedTos) {
 			throw new BadRequestException(

--- a/src/modules/visits/services/visits.service.spec.ts
+++ b/src/modules/visits/services/visits.service.spec.ts
@@ -229,6 +229,30 @@ describe('VisitsService', () => {
 		});
 	});
 
+	describe('getActiveVisitForUserAndSpace', () => {
+		it('returns the active visit for the given user and space', async () => {
+			mockDataService.execute.mockResolvedValueOnce(getDefaultVisitsResponse());
+			const response = await visitsService.getActiveVisitForUserAndSpace('user-1', 'space-1');
+			expect(response.id).toBe(cpVisit.id);
+		});
+
+		it('returns null if the visit was not found', async () => {
+			mockDataService.execute.mockResolvedValueOnce({
+				data: {
+					cp_visit: [],
+					cp_visit_aggregate: {
+						aggregate: {
+							count: 0,
+						},
+					},
+				},
+			});
+			const response = await visitsService.getActiveVisitForUserAndSpace('user-1', 'space-1');
+
+			expect(response).toBeNull();
+		});
+	});
+
 	describe('create', () => {
 		it('can create a new visit', async () => {
 			mockDataService.execute.mockResolvedValueOnce({

--- a/src/modules/visits/services/visits.service.ts
+++ b/src/modules/visits/services/visits.service.ts
@@ -272,6 +272,25 @@ export class VisitsService {
 		return this.adapt(visitResponse.data.cp_visit[0]);
 	}
 
+	public async getActiveVisitForUserAndSpace(
+		userProfileId: string,
+		spaceId: string
+	): Promise<Visit | null> {
+		const visits = await this.findAll({
+			userProfileId,
+			spaceId,
+			timeframe: VisitTimeframe.ACTIVE,
+			status: VisitStatus.APPROVED,
+			size: 1,
+			page: 1,
+		});
+
+		if (visits.total === 0) {
+			return null;
+		}
+		return visits.items[0];
+	}
+
 	public async getApprovedAndStartedVisitsWithoutNotification(): Promise<Visit[]> {
 		const visitsResponse = await this.dataService.execute(
 			FIND_APPROVED_STARTED_VISITS_WITHOUT_NOTIFICATION,


### PR DESCRIPTION
add endpoint to get the active visit for the logged in user in the given space

![CleanShot 2022-03-10 at 13 53 12](https://user-images.githubusercontent.com/8707395/157666690-6a6677cb-2d10-4209-894f-fe280745355c.png)

UPDATED ROUTE:  /visits/active-for-space/:spaceId