### PR TITLE
feat(arc-184): add idp to user info and check-login response

### DIFF
--- a/src/modules/admin/navigations/services/navigations.service.spec.ts
+++ b/src/modules/admin/navigations/services/navigations.service.spec.ts
@@ -4,6 +4,7 @@ import { NavigationsService } from './navigations.service';
 
 import { DataService } from '~modules/data/services/data.service';
 import { User } from '~modules/users/types';
+import { Idp } from '~shared/auth/auth.types';
 
 const mockDataService = {
 	execute: jest.fn(),
@@ -16,6 +17,7 @@ const mockUser: User = {
 	email: 'test@studiohyperdrive.be',
 	acceptedTosAt: '2022-02-21T14:00:00',
 	permissions: ['CREATE_COLLECTION'],
+	idp: Idp.HETARCHIEF,
 };
 
 describe('NavigationsService', () => {

--- a/src/modules/collections/controllers/collections.controller.spec.ts
+++ b/src/modules/collections/controllers/collections.controller.spec.ts
@@ -7,6 +7,7 @@ import { CollectionsController } from './collections.controller';
 
 import { Collection } from '~modules/collections/types';
 import { User } from '~modules/users/types';
+import { Idp } from '~shared/auth/auth.types';
 import { SessionHelper } from '~shared/auth/session-helper';
 
 const mockCollectionsResponse: IPagination<Collection> = {
@@ -60,6 +61,7 @@ const mockUser: User = {
 	email: 'test.testers@meemoo.be',
 	acceptedTosAt: '1997-01-01T00:00:00.000Z',
 	permissions: ['CREATE_COLLECTION'],
+	idp: Idp.HETARCHIEF,
 };
 
 const mockCollectionsService: Partial<Record<keyof CollectionsService, jest.SpyInstance>> = {

--- a/src/modules/notifications/controllers/notifications.controller.spec.ts
+++ b/src/modules/notifications/controllers/notifications.controller.spec.ts
@@ -13,6 +13,7 @@ import { Notification, NotificationStatus, NotificationType } from '~modules/not
 import { User } from '~modules/users/types';
 import { VisitsService } from '~modules/visits/services/visits.service';
 import { Visit, VisitStatus } from '~modules/visits/types';
+import { Idp } from '~shared/auth/auth.types';
 import { SessionHelper } from '~shared/auth/session-helper';
 
 const mockNotification1: Notification = {
@@ -80,6 +81,7 @@ const mockUser: User = {
 	email: 'test.testers@meemoo.be',
 	acceptedTosAt: '1997-01-01T00:00:00.000Z',
 	permissions: ['CREATE_COLLECTION'],
+	idp: Idp.HETARCHIEF,
 };
 
 const mockNotificationsService: Partial<Record<keyof NotificationsService, jest.SpyInstance>> = {

--- a/src/modules/notifications/services/notifications.service.spec.ts
+++ b/src/modules/notifications/services/notifications.service.spec.ts
@@ -9,6 +9,7 @@ import { Notification, NotificationStatus, NotificationType } from '~modules/not
 import { AudienceType, Space } from '~modules/spaces/types';
 import { User } from '~modules/users/types';
 import { Visit, VisitStatus } from '~modules/visits/types';
+import { Idp } from '~shared/auth/auth.types';
 
 const mockGqlNotification1 = {
 	description:
@@ -67,6 +68,7 @@ const mockUser: User = {
 	email: 'test.testers@meemoo.be',
 	acceptedTosAt: '2022-01-24T17:21:58.937169+00:00',
 	permissions: ['CREATE_COLLECTION'],
+	idp: Idp.HETARCHIEF,
 };
 
 const mockVisit: Visit = {

--- a/src/modules/users/services/queries.gql.ts
+++ b/src/modules/users/services/queries.gql.ts
@@ -13,6 +13,9 @@ export const GET_USER_BY_IDENTITY_ID = `
 					}
 				}
 			}
+			identities {
+				identity_provider_name
+			}
 		}
 	}
 `;
@@ -31,6 +34,9 @@ export const INSERT_USER = `
 						name
 					}
 				}
+			}
+			identities {
+				identity_provider_name
 			}
 		}
 	}
@@ -58,6 +64,9 @@ export const UPDATE_USER = `
 						name
 					}
 				}
+			}
+			identities {
+				identity_provider_name
 			}
 		}
 	}

--- a/src/modules/users/services/users.service.ts
+++ b/src/modules/users/services/users.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { get } from 'lodash';
 
 import { CreateUserDto, UpdateAcceptedTosDto, UpdateUserDto } from '../dto/users.dto';
-import { GqlPermissionData, User } from '../types';
+import { GqlPermissionData, GqlUser, User } from '../types';
 
 import {
 	GET_USER_BY_IDENTITY_ID,
@@ -20,7 +20,7 @@ export class UsersService {
 
 	constructor(protected dataService: DataService) {}
 
-	public adapt(graphQlUser: any): User {
+	public adapt(graphQlUser: GqlUser): User | null {
 		return {
 			id: get(graphQlUser, 'id'),
 			firstName: get(graphQlUser, 'first_name'),
@@ -30,6 +30,7 @@ export class UsersService {
 			permissions: get(graphQlUser, 'group.permissions', []).map(
 				(permData: GqlPermissionData) => permData.permission.name
 			),
+			idp: get(graphQlUser, 'identities[0].identity_provider_name'),
 		};
 	}
 

--- a/src/modules/users/types.ts
+++ b/src/modules/users/types.ts
@@ -1,3 +1,25 @@
+import { Idp } from '~shared/auth/auth.types';
+
+export interface GqlUser {
+	id: string;
+	first_name: string;
+	last_name: string;
+	mail: string;
+	accepted_tos_at?: string;
+	group: GqlUserGroup;
+	identities: {
+		identity_provider_name: string;
+	}[];
+}
+
+export interface GqlUserGroup {
+	permissions: {
+		permission: {
+			name: string;
+		};
+	}[];
+}
+
 export interface User {
 	id: string;
 	firstName: string;
@@ -5,6 +27,7 @@ export interface User {
 	email: string;
 	acceptedTosAt: string;
 	permissions: string[];
+	idp: Idp;
 }
 
 export interface GqlPermission {

--- a/src/modules/visits/controllers/visits.controller.spec.ts
+++ b/src/modules/visits/controllers/visits.controller.spec.ts
@@ -10,6 +10,7 @@ import { NotificationsService } from '~modules/notifications/services/notificati
 import { SpacesService } from '~modules/spaces/services/spaces.service';
 import { AudienceType, Space } from '~modules/spaces/types';
 import { User } from '~modules/users/types';
+import { Idp } from '~shared/auth/auth.types';
 import { SessionHelper } from '~shared/auth/session-helper';
 import i18n from '~shared/i18n';
 
@@ -65,6 +66,7 @@ const mockUser: User = {
 	email: 'test.testers@meemoo.be',
 	acceptedTosAt: '1997-01-01T00:00:00.000Z',
 	permissions: ['CREATE_COLLECTION'],
+	idp: Idp.HETARCHIEF,
 };
 
 const mockSpace: Space = {

--- a/src/shared/auth/session-helper.spec.ts
+++ b/src/shared/auth/session-helper.spec.ts
@@ -1,6 +1,7 @@
 import { addDays, setHours, setMilliseconds, setMinutes, setSeconds } from 'date-fns/fp';
 import flow from 'lodash/fp/flow';
 
+import { User } from '~modules/users/types';
 import { Idp } from '~shared/auth/auth.types';
 import { SessionHelper } from '~shared/auth/session-helper';
 
@@ -24,13 +25,14 @@ const mockLdapUser = {
 	},
 };
 
-const mockArchiefUser = {
+const mockArchiefUser: User = {
 	id: 'c59492f7-a317-4dd6-b1ff-5cd2a3ea042d',
 	firstName: 'Tom',
 	lastName: 'Testerom',
 	email: 'test@studiohyperdrive.be',
 	acceptedTosAt: '2022-02-21T14:00:00',
 	permissions: ['CREATE_COLLECTION'],
+	idp: Idp.HETARCHIEF,
 };
 
 describe('SessionHelper', () => {


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-184

still todo:
* ensure fresh user data is fetched from ldap after the user updates his info in on the ssum page
* check if "change password" button should also be shown?

Hetarchief idp users can see the "edit profile settings" button:
![image](https://user-images.githubusercontent.com/1710840/158645948-abc1d818-c054-4c32-a3af-9b7f2e52b8d2.png)

It redirect to the ssum edit page:
![image](https://user-images.githubusercontent.com/1710840/158645995-f341c51a-33cd-4ea5-a42a-b84c1a849eb3.png)

And after saving your changes it redirect back to the profile page:
![image](https://user-images.githubusercontent.com/1710840/158646044-b9d73fc3-4a5e-41c9-a9e3-1c87f8063b60.png)
