### PR TITLE
feat(arc-592): change visits route to allow cp-admins and meemoo-admins

### DIFF
--- a/src/modules/admin/navigations/services/navigations.service.spec.ts
+++ b/src/modules/admin/navigations/services/navigations.service.spec.ts
@@ -3,7 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { NavigationsService } from './navigations.service';
 
 import { DataService } from '~modules/data/services/data.service';
-import { User } from '~modules/users/types';
+import { Permission, User } from '~modules/users/types';
 import { Idp } from '~shared/auth/auth.types';
 
 const mockDataService = {
@@ -16,7 +16,7 @@ const mockUser: User = {
 	lastName: 'Testerom',
 	email: 'test@studiohyperdrive.be',
 	acceptedTosAt: '2022-02-21T14:00:00',
-	permissions: ['CREATE_COLLECTION'],
+	permissions: [Permission.CAN_READ_CP_VISIT_REQUESTS],
 	idp: Idp.HETARCHIEF,
 };
 

--- a/src/modules/auth/controllers/het-archief.controller.ts
+++ b/src/modules/auth/controllers/het-archief.controller.ts
@@ -19,6 +19,7 @@ import { RelayState, SamlCallbackBody } from '../types';
 
 import { CollectionsService } from '~modules/collections/services/collections.service';
 import { UsersService } from '~modules/users/services/users.service';
+import { Permission } from '~modules/users/types';
 import { Idp, LdapUser } from '~shared/auth/auth.types';
 import { SessionHelper } from '~shared/auth/session-helper';
 import i18n from '~shared/i18n';
@@ -125,6 +126,13 @@ export class HetArchiefController {
 					archiefUser = await this.usersService.updateUser(archiefUser.id, userDto);
 				}
 			}
+
+			// TODO remove this temp permissions array once we can login wit the correct user group --------------------------
+			archiefUser.permissions = [
+				Permission.CAN_READ_CP_VISIT_REQUESTS,
+				Permission.CAN_APPROVE_DENY_ALL_VISIT_REQUESTS,
+			];
+			// TODO remove until here ----------------------------------------------------------------------------------------
 
 			SessionHelper.setArchiefUserInfo(session, archiefUser);
 

--- a/src/modules/collections/controllers/collections.controller.spec.ts
+++ b/src/modules/collections/controllers/collections.controller.spec.ts
@@ -6,7 +6,7 @@ import { CollectionsService } from '../services/collections.service';
 import { CollectionsController } from './collections.controller';
 
 import { Collection } from '~modules/collections/types';
-import { User } from '~modules/users/types';
+import { Permission, User } from '~modules/users/types';
 import { Idp } from '~shared/auth/auth.types';
 import { SessionHelper } from '~shared/auth/session-helper';
 
@@ -60,7 +60,7 @@ const mockUser: User = {
 	lastName: 'Testers',
 	email: 'test.testers@meemoo.be',
 	acceptedTosAt: '1997-01-01T00:00:00.000Z',
-	permissions: ['CREATE_COLLECTION'],
+	permissions: [Permission.CAN_READ_CP_VISIT_REQUESTS],
 	idp: Idp.HETARCHIEF,
 };
 

--- a/src/modules/notifications/controllers/notifications.controller.spec.ts
+++ b/src/modules/notifications/controllers/notifications.controller.spec.ts
@@ -10,7 +10,7 @@ import { NotificationsService } from '../services/notifications.service';
 import { NotificationsController } from './notifications.controller';
 
 import { Notification, NotificationStatus, NotificationType } from '~modules/notifications/types';
-import { User } from '~modules/users/types';
+import { Permission, User } from '~modules/users/types';
 import { VisitsService } from '~modules/visits/services/visits.service';
 import { Visit, VisitStatus } from '~modules/visits/types';
 import { Idp } from '~shared/auth/auth.types';
@@ -80,7 +80,7 @@ const mockUser: User = {
 	lastName: 'Testers',
 	email: 'test.testers@meemoo.be',
 	acceptedTosAt: '1997-01-01T00:00:00.000Z',
-	permissions: ['CREATE_COLLECTION'],
+	permissions: [Permission.CAN_READ_CP_VISIT_REQUESTS],
 	idp: Idp.HETARCHIEF,
 };
 

--- a/src/modules/notifications/services/notifications.service.spec.ts
+++ b/src/modules/notifications/services/notifications.service.spec.ts
@@ -7,7 +7,7 @@ import { DataService } from '~modules/data/services/data.service';
 import { mockGqlNotification } from '~modules/notifications/services/__mocks__/app_notification';
 import { Notification, NotificationStatus, NotificationType } from '~modules/notifications/types';
 import { AudienceType, Space } from '~modules/spaces/types';
-import { User } from '~modules/users/types';
+import { Permission, User } from '~modules/users/types';
 import { Visit, VisitStatus } from '~modules/visits/types';
 import { Idp } from '~shared/auth/auth.types';
 
@@ -67,7 +67,7 @@ const mockUser: User = {
 	lastName: 'Testers',
 	email: 'test.testers@meemoo.be',
 	acceptedTosAt: '2022-01-24T17:21:58.937169+00:00',
-	permissions: ['CREATE_COLLECTION'],
+	permissions: [Permission.CAN_READ_CP_VISIT_REQUESTS],
 	idp: Idp.HETARCHIEF,
 };
 

--- a/src/modules/spaces/controllers/spaces.controller.spec.ts
+++ b/src/modules/spaces/controllers/spaces.controller.spec.ts
@@ -58,5 +58,21 @@ describe('SpacesController', () => {
 			const space = await spacesController.getSpaceById('1');
 			expect(space.id).toEqual('1');
 		});
+
+		it("should throw a not found exception for space that doesn't exist", async () => {
+			mockSpacesService.findById.mockResolvedValueOnce(null);
+
+			let error;
+			try {
+				await spacesController.getSpaceById('1');
+			} catch (err) {
+				error = err;
+			}
+			expect(error?.response).toEqual({
+				statusCode: 404,
+				message: 'Space with id 1 not found',
+				error: 'Not Found',
+			});
+		});
 	});
 });

--- a/src/modules/spaces/controllers/spaces.controller.ts
+++ b/src/modules/spaces/controllers/spaces.controller.ts
@@ -1,10 +1,20 @@
-import { Controller, Get, Logger, Param, ParseUUIDPipe, Query } from '@nestjs/common';
+import {
+	Controller,
+	Get,
+	Logger,
+	NotFoundException,
+	Param,
+	ParseUUIDPipe,
+	Query,
+} from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { IPagination } from '@studiohyperdrive/pagination';
 
 import { SpacesQueryDto } from '../dto/spaces.dto';
 import { SpacesService } from '../services/spaces.service';
 import { Space } from '../types';
+
+import i18n from '~shared/i18n';
 
 @ApiTags('Spaces')
 @Controller('spaces')
@@ -20,8 +30,11 @@ export class SpacesController {
 	}
 
 	@Get(':id')
-	public async getSpaceById(@Param('id', ParseUUIDPipe) id: string): Promise<Space> {
+	public async getSpaceById(@Param('id', ParseUUIDPipe) id: string): Promise<Space | null> {
 		const space = await this.spacesService.findById(id);
+		if (!space) {
+			throw new NotFoundException(i18n.t(`Space with id ${id} not found`));
+		}
 		return space;
 	}
 }

--- a/src/modules/spaces/services/queries.gql.ts
+++ b/src/modules/spaces/services/queries.gql.ts
@@ -79,6 +79,45 @@ export const FIND_SPACE_BY_ID = `
 	}
 `;
 
+export const FIND_SPACE_BY_CP_ADMIN_ID = `
+query spaces($cpAdminId: uuid!) {
+  cp_space(where: {schema_maintainer: {maintainer_users_profiles: {users_profile_id: {_eq: $cpAdminId}}}}) {
+    id
+    schema_image
+    schema_color
+    schema_audience_type
+    schema_description
+    schema_public_access
+    schema_service_description
+    is_published
+    published_at
+    created_at
+    updated_at
+    schema_maintainer {
+      schema_name
+      schema_identifier
+      information {
+        description
+        logo {
+          iri
+        }
+        primary_site {
+          address {
+            email
+            locality
+            postal_code
+            street
+            telephone
+            post_office_box_number
+          }
+        }
+      }
+    }
+  }
+}
+
+`;
+
 export const GET_SPACE_MAINTAINER_PROFILE_IDS = `
 	query getNotificationsForUser($spaceId: uuid) {
 		cp_maintainer_users_profile(where: {maintainer: {space: {id: {_eq: $spaceId}}}}) {

--- a/src/modules/spaces/services/spaces.service.spec.ts
+++ b/src/modules/spaces/services/spaces.service.spec.ts
@@ -91,22 +91,42 @@ describe('SpacesService', () => {
 			expect(response.id).toBe('1');
 		});
 
-		it('throws a notfoundexception if the space was not found', async () => {
+		it('returns null if the space was not found', async () => {
 			mockDataService.execute.mockResolvedValueOnce({
 				data: {
 					cp_space: [],
 				},
 			});
-			let error;
-			try {
-				await spacesService.findById('unknown-id');
-			} catch (e) {
-				error = e;
-			}
-			expect(error.response).toEqual({
-				message: 'Not Found',
-				statusCode: 404,
+
+			const space = await spacesService.findById('unknown-id');
+			expect(space).toBeNull();
+		});
+	});
+
+	describe('findSpaceByCpUserId', () => {
+		it('returns a single space', async () => {
+			mockDataService.execute.mockResolvedValueOnce({
+				data: {
+					cp_space: [
+						{
+							id: '1',
+						},
+					],
+				},
 			});
+			const response = await spacesService.findSpaceByCpUserId('1');
+			expect(response.id).toBe('1');
+		});
+
+		it('returns null if the space was not found', async () => {
+			mockDataService.execute.mockResolvedValueOnce({
+				data: {
+					cp_space: [],
+				},
+			});
+
+			const space = await spacesService.findSpaceByCpUserId('unknown-id');
+			expect(space).toBeNull();
 		});
 	});
 

--- a/src/modules/spaces/services/spaces.service.ts
+++ b/src/modules/spaces/services/spaces.service.ts
@@ -5,7 +5,12 @@ import { get, isEmpty, set } from 'lodash';
 import { SpacesQueryDto } from '../dto/spaces.dto';
 import { Space } from '../types';
 
-import { FIND_SPACE_BY_ID, FIND_SPACES, GET_SPACE_MAINTAINER_PROFILE_IDS } from './queries.gql';
+import {
+	FIND_SPACE_BY_CP_ADMIN_ID,
+	FIND_SPACE_BY_ID,
+	FIND_SPACES,
+	GET_SPACE_MAINTAINER_PROFILE_IDS,
+} from './queries.gql';
 
 import { DataService } from '~modules/data/services/data.service';
 import { PaginationHelper } from '~shared/helpers/pagination';
@@ -86,10 +91,20 @@ export class SpacesService {
 		});
 	}
 
-	public async findById(id: string): Promise<Space> {
+	public async findById(id: string): Promise<Space | null> {
 		const spaceResponse = await this.dataService.execute(FIND_SPACE_BY_ID, { id });
 		if (!spaceResponse.data.cp_space[0]) {
-			throw new NotFoundException();
+			return null;
+		}
+		return this.adapt(spaceResponse.data.cp_space[0]);
+	}
+
+	public async findSpaceByCpUserId(cpAdminId: string): Promise<Space | null> {
+		const spaceResponse = await this.dataService.execute(FIND_SPACE_BY_CP_ADMIN_ID, {
+			cpAdminId,
+		});
+		if (!spaceResponse.data.cp_space[0]) {
+			return null;
 		}
 		return this.adapt(spaceResponse.data.cp_space[0]);
 	}

--- a/src/modules/users/types.ts
+++ b/src/modules/users/types.ts
@@ -1,5 +1,12 @@
 import { Idp } from '~shared/auth/auth.types';
 
+export enum Permission {
+	CAN_READ_ALL_VISIT_REQUESTS = 'CAN_READ_ALL_VISIT_REQUESTS',
+	CAN_APPROVE_DENY_ALL_VISIT_REQUESTS = 'CAN_APPROVE_DENY_ALL_VISIT_REQUESTS',
+	CAN_READ_CP_VISIT_REQUESTS = 'CAN_READ_CP_VISIT_REQUESTS',
+	CAN_APPROVE_DENY_CP_VISIT_REQUESTS = 'CAN_APPROVE_DENY_CP_VISIT_REQUESTS',
+}
+
 export interface GqlUser {
 	id: string;
 	first_name: string;
@@ -26,7 +33,7 @@ export interface User {
 	lastName: string;
 	email: string;
 	acceptedTosAt: string;
-	permissions: string[];
+	permissions: Permission[];
 	idp: Idp;
 }
 

--- a/src/modules/visits/controllers/visits.controller.spec.ts
+++ b/src/modules/visits/controllers/visits.controller.spec.ts
@@ -9,9 +9,10 @@ import { VisitsController } from './visits.controller';
 import { NotificationsService } from '~modules/notifications/services/notifications.service';
 import { SpacesService } from '~modules/spaces/services/spaces.service';
 import { AudienceType, Space } from '~modules/spaces/types';
-import { User } from '~modules/users/types';
+import { Permission, User } from '~modules/users/types';
 import { Idp } from '~shared/auth/auth.types';
 import { SessionHelper } from '~shared/auth/session-helper';
+import { SessionUser } from '~shared/decorators/user.decorator';
 import i18n from '~shared/i18n';
 
 const mockVisit1: Visit = {
@@ -65,7 +66,7 @@ const mockUser: User = {
 	lastName: 'Testers',
 	email: 'test.testers@meemoo.be',
 	acceptedTosAt: '1997-01-01T00:00:00.000Z',
-	permissions: ['CREATE_COLLECTION'],
+	permissions: [Permission.CAN_READ_ALL_VISIT_REQUESTS],
 	idp: Idp.HETARCHIEF,
 };
 
@@ -115,6 +116,7 @@ const mockNotificationsService: Partial<Record<keyof NotificationsService, jest.
 const mockSpacesService: Partial<Record<keyof SpacesService, jest.SpyInstance>> = {
 	getMaintainerProfileIds: jest.fn(),
 	findById: jest.fn(),
+	findSpaceByCpUserId: jest.fn(),
 };
 
 describe('VisitsController', () => {
@@ -154,10 +156,68 @@ describe('VisitsController', () => {
 	});
 
 	describe('getVisits', () => {
-		it('should return all visits', async () => {
+		it('should return all visits for meemoo admin', async () => {
 			mockVisitsService.findAll.mockResolvedValueOnce(mockVisitsResponse);
-			const visits = await visitsController.getVisits(null);
+
+			const visits = await visitsController.getVisits(null, {
+				...mockUser,
+				permissions: [Permission.CAN_READ_ALL_VISIT_REQUESTS],
+			});
+
 			expect(visits).toEqual(mockVisitsResponse);
+		});
+
+		it('should return all visits of a single cpSpace for cp admin', async () => {
+			mockVisitsService.findAll.mockResolvedValueOnce(mockVisitsResponse);
+			mockSpacesService.findSpaceByCpUserId.mockResolvedValueOnce(mockSpace);
+
+			const visits = await visitsController.getVisits(null, {
+				...mockUser,
+				permissions: [Permission.CAN_READ_CP_VISIT_REQUESTS],
+			});
+
+			expect(visits).toEqual(mockVisitsResponse);
+		});
+
+		it('should throw a not found exception if the maintainer is not linked to any cp users', async () => {
+			mockVisitsService.findAll.mockResolvedValueOnce(mockVisitsResponse);
+			mockSpacesService.findSpaceByCpUserId.mockResolvedValueOnce(null);
+
+			let error;
+			try {
+				await visitsController.getVisits(null, {
+					...mockUser,
+					permissions: [Permission.CAN_READ_CP_VISIT_REQUESTS],
+				});
+			} catch (err) {
+				error = err;
+			}
+
+			expect(error.response).toEqual({
+				statusCode: 404,
+				message: 'The current user does not seem to be linked to a cp space.',
+				error: 'Not Found',
+			});
+		});
+
+		it('should throw an unauthorized error for regular visitors', async () => {
+			mockVisitsService.findAll.mockResolvedValueOnce(mockVisitsResponse);
+
+			let error;
+			try {
+				await visitsController.getVisits(null, {
+					...mockUser,
+					permissions: [],
+				});
+			} catch (err) {
+				error = err;
+			}
+
+			expect(error?.response).toEqual({
+				error: 'Unauthorized',
+				message: 'You do not have the right permissions to call this route',
+				statusCode: 401,
+			});
 		});
 	});
 

--- a/src/modules/visits/dto/visits.dto.ts
+++ b/src/modules/visits/dto/visits.dto.ts
@@ -101,24 +101,6 @@ export class VisitsQueryDto {
 	})
 	query?: string;
 
-	@IsUUID()
-	@IsOptional()
-	@ApiPropertyOptional({
-		type: String,
-		description: 'Get all visits for this user',
-		default: undefined,
-	})
-	userProfileId?: string;
-
-	@IsUUID()
-	@IsOptional()
-	@ApiPropertyOptional({
-		type: String,
-		description: 'Get all visits for this space',
-		default: undefined,
-	})
-	spaceId?: string;
-
 	@ApiPropertyOptional({
 		isArray: true,
 		required: false,

--- a/src/modules/visits/services/visits.service.spec.ts
+++ b/src/modules/visits/services/visits.service.spec.ts
@@ -80,19 +80,22 @@ describe('VisitsService', () => {
 	describe('findAll', () => {
 		it('returns a paginated response with all visits', async () => {
 			mockDataService.execute.mockResolvedValueOnce(getDefaultVisitsResponse());
-			const response = await visitsService.findAll({
-				query: '%',
-				status: undefined,
-				page: 1,
-				size: 10,
-			});
+			const response = await visitsService.findAll(
+				{
+					query: '%',
+					status: undefined,
+					page: 1,
+					size: 10,
+				},
+				null
+			);
 			expect(response.items.length).toBe(1);
 			expect(response.page).toBe(1);
 			expect(response.size).toBe(10);
 			expect(response.total).toBe(100);
 		});
 
-		it('returns a paginated response with visits containing maria', async () => {
+		it('returns a paginated response with visits containing maria across all cpSpaces', async () => {
 			mockDataService.execute.mockResolvedValueOnce({
 				data: {
 					cp_visit: [
@@ -112,12 +115,52 @@ describe('VisitsService', () => {
 					},
 				},
 			});
-			const response = await visitsService.findAll({
-				query: '%Marie%',
-				status: VisitStatus.APPROVED,
-				page: 1,
-				size: 10,
+			const response = await visitsService.findAll(
+				{
+					query: '%Marie%',
+					status: VisitStatus.APPROVED,
+					page: 1,
+					size: 10,
+				},
+				null
+			);
+			expect(response.items.length).toBe(1);
+			expect(response.items[0]?.visitorName).toContain('Marie');
+			expect(response.items[0]?.status).toEqual(VisitStatus.APPROVED);
+			expect(response.page).toBe(1);
+			expect(response.size).toBe(10);
+			expect(response.total).toBe(100);
+		});
+
+		it('returns a paginated response with visits containing maria within one cpSpace', async () => {
+			mockDataService.execute.mockResolvedValueOnce({
+				data: {
+					cp_visit: [
+						{
+							id: '1',
+							status: 'APPROVED',
+							user_profile: {
+								first_name: 'Marie',
+								last_name: 'Odhiambo',
+							},
+						},
+					],
+					cp_visit_aggregate: {
+						aggregate: {
+							count: 100,
+						},
+					},
+				},
 			});
+			const response = await visitsService.findAll(
+				{
+					query: '%Marie%',
+					status: VisitStatus.APPROVED,
+					page: 1,
+					size: 10,
+				},
+				'space-1'
+			);
 			expect(response.items.length).toBe(1);
 			expect(response.items[0]?.visitorName).toContain('Marie');
 			expect(response.items[0]?.status).toEqual(VisitStatus.APPROVED);
@@ -128,34 +171,26 @@ describe('VisitsService', () => {
 
 		it('can filter on an array of statuses', async () => {
 			mockDataService.execute.mockResolvedValueOnce(getDefaultVisitsResponse());
-			const response = await visitsService.findAll({
-				status: [VisitStatus.APPROVED, VisitStatus.DENIED],
-				page: 1,
-				size: 10,
-			});
+			const response = await visitsService.findAll(
+				{
+					status: [VisitStatus.APPROVED, VisitStatus.DENIED],
+					page: 1,
+					size: 10,
+				},
+				null
+			);
 			expect(response.items.length).toBe(1);
-		});
-
-		it('can filter on userProfileId', async () => {
-			mockDataService.execute.mockResolvedValueOnce(getDefaultVisitsResponse());
-			const response = await visitsService.findAll({
-				userProfileId: 'user-1',
-				page: 1,
-				size: 10,
-			});
-			expect(response.items.length).toBe(1);
-			expect(response.page).toBe(1);
-			expect(response.size).toBe(10);
-			expect(response.total).toBe(100);
 		});
 
 		it('can filter on spaceId', async () => {
 			mockDataService.execute.mockResolvedValueOnce(getDefaultVisitsResponse());
-			const response = await visitsService.findAll({
-				spaceId: 'space-1',
-				page: 1,
-				size: 10,
-			});
+			const response = await visitsService.findAll(
+				{
+					page: 1,
+					size: 10,
+				},
+				'space-1'
+			);
 			expect(response.items.length).toBe(1);
 			expect(response.page).toBe(1);
 			expect(response.size).toBe(10);
@@ -164,11 +199,14 @@ describe('VisitsService', () => {
 
 		it('can filter on timeframe ACTIVE', async () => {
 			mockDataService.execute.mockResolvedValueOnce(getDefaultVisitsResponse());
-			const response = await visitsService.findAll({
-				timeframe: VisitTimeframe.ACTIVE,
-				page: 1,
-				size: 10,
-			});
+			const response = await visitsService.findAll(
+				{
+					timeframe: VisitTimeframe.ACTIVE,
+					page: 1,
+					size: 10,
+				},
+				null
+			);
 			expect(response.items.length).toBe(1);
 			expect(response.page).toBe(1);
 			expect(response.size).toBe(10);
@@ -177,11 +215,14 @@ describe('VisitsService', () => {
 
 		it('can filter on timeframe FUTURE', async () => {
 			mockDataService.execute.mockResolvedValueOnce(getDefaultVisitsResponse());
-			const response = await visitsService.findAll({
-				timeframe: VisitTimeframe.FUTURE,
-				page: 1,
-				size: 10,
-			});
+			const response = await visitsService.findAll(
+				{
+					timeframe: VisitTimeframe.FUTURE,
+					page: 1,
+					size: 10,
+				},
+				null
+			);
 			expect(response.items.length).toBe(1);
 			expect(response.page).toBe(1);
 			expect(response.size).toBe(10);
@@ -190,11 +231,14 @@ describe('VisitsService', () => {
 
 		it('can filter on timeframe PAST', async () => {
 			mockDataService.execute.mockResolvedValueOnce(getDefaultVisitsResponse());
-			const response = await visitsService.findAll({
-				timeframe: VisitTimeframe.PAST,
-				page: 1,
-				size: 10,
-			});
+			const response = await visitsService.findAll(
+				{
+					timeframe: VisitTimeframe.PAST,
+					page: 1,
+					size: 10,
+				},
+				null
+			);
 			expect(response.items.length).toBe(1);
 			expect(response.page).toBe(1);
 			expect(response.size).toBe(10);

--- a/src/shared/auth/session-helper.spec.ts
+++ b/src/shared/auth/session-helper.spec.ts
@@ -1,7 +1,7 @@
 import { addDays, setHours, setMilliseconds, setMinutes, setSeconds } from 'date-fns/fp';
 import flow from 'lodash/fp/flow';
 
-import { User } from '~modules/users/types';
+import { Permission, User } from '~modules/users/types';
 import { Idp } from '~shared/auth/auth.types';
 import { SessionHelper } from '~shared/auth/session-helper';
 
@@ -31,7 +31,7 @@ const mockArchiefUser: User = {
 	lastName: 'Testerom',
 	email: 'test@studiohyperdrive.be',
 	acceptedTosAt: '2022-02-21T14:00:00',
-	permissions: ['CREATE_COLLECTION'],
+	permissions: [Permission.CAN_READ_ALL_VISIT_REQUESTS],
 	idp: Idp.HETARCHIEF,
 };
 

--- a/src/shared/auth/session-helper.ts
+++ b/src/shared/auth/session-helper.ts
@@ -8,7 +8,7 @@ import { Idp, LdapUser } from '~shared/auth/auth.types';
 
 const IDP = 'idp';
 const IDP_USER_INFO_PATH = 'idpUserInfo';
-const ARCHIEF_USER_INFO_PATH = 'archiefUserInfo';
+export const ARCHIEF_USER_INFO_PATH = 'archiefUserInfo';
 
 export class SessionHelper {
 	public static ensureValidSession(session: Record<string, any>) {

--- a/src/shared/decorators/user.decorator.ts
+++ b/src/shared/decorators/user.decorator.ts
@@ -1,0 +1,11 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+import { User } from '~modules/users/types';
+import { SessionHelper } from '~shared/auth/session-helper';
+
+export const SessionUser = createParamDecorator(
+	(data: unknown, ctx: ExecutionContext): User | null => {
+		const request = ctx.switchToHttp().getRequest();
+		return SessionHelper.getArchiefUserInfo(request.session);
+	}
+);


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-592

* check permissions based on logged in user
* add mock permissions array for the hetarchief idp
* add @SessionUser decorator for easy access to user object
* add service function to get space by cpAdmin profile id
* avoid throwing exceptions in services for not found cases. So we can reuse the service functions for other purposes
* removed filter option for userProfileId => we'll use the session user id
* remove filter option for spaceId => we'll use the space that is linked to the current session user