### PR TITLE
fix(session-helper): ensure fake permissions are not reset on tos accept

### DIFF
--- a/src/modules/auth/controllers/het-archief.controller.ts
+++ b/src/modules/auth/controllers/het-archief.controller.ts
@@ -127,16 +127,6 @@ export class HetArchiefController {
 				}
 			}
 
-			// TODO remove this temp permissions array once we can login wit the correct user group --------------------------
-			archiefUser.permissions = [
-				Permission.CAN_READ_ALL_VISIT_REQUESTS,
-				Permission.CAN_READ_CP_VISIT_REQUESTS,
-				Permission.CAN_APPROVE_DENY_ALL_VISIT_REQUESTS,
-				Permission.CAN_APPROVE_DENY_CP_VISIT_REQUESTS,
-				Permission.CAN_READ_PERSONAL_APPROVED_VISIT_REQUESTS,
-			];
-			// TODO remove until here ----------------------------------------------------------------------------------------
-
 			SessionHelper.setArchiefUserInfo(session, archiefUser);
 
 			return {

--- a/src/shared/auth/session-helper.ts
+++ b/src/shared/auth/session-helper.ts
@@ -3,7 +3,7 @@ import { addDays, getHours, setHours, setMilliseconds, setMinutes, setSeconds } 
 import { get } from 'lodash';
 import flow from 'lodash/fp/flow';
 
-import { User } from '~modules/users/types';
+import { Permission, User } from '~modules/users/types';
 import { Idp, LdapUser } from '~shared/auth/auth.types';
 
 const IDP = 'idp';
@@ -72,6 +72,17 @@ export class SessionHelper {
 	 */
 	public static setArchiefUserInfo(session: Record<string, any>, user: User): void {
 		SessionHelper.ensureValidSession(session);
+
+		// TODO remove this temp permissions array once we can login wit the correct user group --------------------------
+		user.permissions = [
+			Permission.CAN_READ_ALL_VISIT_REQUESTS,
+			Permission.CAN_READ_CP_VISIT_REQUESTS,
+			Permission.CAN_APPROVE_DENY_ALL_VISIT_REQUESTS,
+			Permission.CAN_APPROVE_DENY_CP_VISIT_REQUESTS,
+			Permission.CAN_READ_PERSONAL_APPROVED_VISIT_REQUESTS,
+		];
+		// TODO remove until here ----------------------------------------------------------------------------------------
+
 		session[ARCHIEF_USER_INFO_PATH] = user;
 	}
 


### PR DESCRIPTION
otherwise you can get into this scenario:
* re-seed the database
* login to the app (your session gets a list of permissions)
* make a visit request
* go to cp admin visit requests
* you need to accept the tos first
* accept tos
* during the update call, a new user object is set on the session, overwriting the earlier fake list
* visits call fails, because you do not have permissions