### PR TITLE
feat(arc-288): update freetext search in collection objects

### DIFF
--- a/src/modules/collections/services/collections.service.ts
+++ b/src/modules/collections/services/collections.service.ts
@@ -172,7 +172,15 @@ export class CollectionsService {
 	): Promise<IPagination<IeObject>> {
 		const { query, page, size } = queryDto;
 		const { offset, limit } = PaginationHelper.convertPagination(page, size);
-		const where = { ie: { schema_name: { _ilike: query } } };
+		const where = {
+			_or: [
+				{ ie: { schema_name: { _ilike: query } } },
+				{ ie: { maintainer: { schema_name: { _ilike: query } } } },
+				{ ie: { dcterms_format: { _ilike: query } } },
+				{ ie: { meemoo_identifier: { _ilike: query } } },
+				{ ie: { schema_identifier: { _ilike: query } } },
+			],
+		};
 		const collectionObjectsResponse =
 			await this.dataService.execute<FindCollectionObjectsByCollectionIdQuery>(
 				FindCollectionObjectsByCollectionIdDocument,


### PR DESCRIPTION
Metadata shown for collection item in FE:
	  maintainerName
	  series
	  programs
	  format
	  dateCreatedLowerBound
	  datePublished
	  meemooIdentifier
	  schemaIdentifier

- series & programs: not queryable using freetext since stored as jsonb in DB
- dateCreatedLowerBound en datePublished  not queryable using freetext since they require an exact date format