### PR TITLE
feat(arc-769): Add data and path, trigger metadata export events

### DIFF
--- a/src/modules/collections/controllers/collections.controller.spec.ts
+++ b/src/modules/collections/controllers/collections.controller.spec.ts
@@ -176,7 +176,8 @@ describe('CollectionsController', () => {
 			const result = await collectionsController.exportCollection(
 				'referer',
 				'collection-id',
-				new SessionUserEntity(mockUser)
+				new SessionUserEntity(mockUser),
+				mockRequest
 			);
 			expect(result).toEqual('</objects>');
 		});

--- a/src/modules/collections/controllers/collections.controller.ts
+++ b/src/modules/collections/controllers/collections.controller.ts
@@ -85,12 +85,25 @@ export class CollectionsController {
 	public async exportCollection(
 		@Headers('referer') referer: string,
 		@Param('collectionId', ParseUUIDPipe) collectionId: string,
-		@SessionUser() user: SessionUserEntity
+		@SessionUser() user: SessionUserEntity,
+		@Req() request: Request
 	): Promise<string> {
 		const objects = await this.mediaService.findAllObjectMetadataByCollectionId(
 			collectionId,
 			user.getId()
 		);
+
+		// Log event
+		this.eventsService.insertEvents([
+			{
+				id: EventsHelper.getEventId(request),
+				type: LogEventType.METADATA_EXPORT,
+				source: request.path,
+				subject: user.getId(),
+				time: new Date().toISOString(),
+			},
+		]);
+
 		return this.mediaService.convertObjectsToXml(objects);
 	}
 

--- a/src/modules/events/controllers/events.controller.spec.ts
+++ b/src/modules/events/controllers/events.controller.spec.ts
@@ -27,6 +27,8 @@ const mockUser: User = {
 	idp: Idp.HETARCHIEF,
 };
 
+const mockRequest = { path: '/events', headers: {} } as unknown as Request;
+
 describe('EventsController', () => {
 	let eventsController: EventsController;
 	beforeEach(async () => {
@@ -50,9 +52,22 @@ describe('EventsController', () => {
 	describe('sendEvent', () => {
 		it('should send log events', async () => {
 			const result = eventsController.sendEvent(
-				{ path: '/events', headers: {} } as unknown as Request,
+				mockRequest,
 				new SessionUserEntity(mockUser),
-				{ type: LogEventType.USER_AUTHENTICATE }
+				{ type: LogEventType.USER_AUTHENTICATE, path: 'http://localhost:3200' }
+			);
+			expect(result).toBeTruthy();
+		});
+
+		it('should send log events with data', async () => {
+			const result = eventsController.sendEvent(
+				mockRequest,
+				new SessionUserEntity(mockUser),
+				{
+					type: LogEventType.USER_AUTHENTICATE,
+					path: 'http://localhost:3200',
+					data: { test: true },
+				}
 			);
 			expect(result).toBeTruthy();
 		});

--- a/src/modules/events/controllers/events.controller.ts
+++ b/src/modules/events/controllers/events.controller.ts
@@ -37,7 +37,6 @@ export class EventsController {
 			logEvent.data = createEventsDto.data;
 		}
 
-		// We do not await this one to not let the client wait the response
 		await this.eventsService.insertEvents([logEvent]);
 
 		return true;

--- a/src/modules/events/controllers/events.controller.ts
+++ b/src/modules/events/controllers/events.controller.ts
@@ -5,6 +5,7 @@ import { Request } from 'express';
 import { CreateEventsDto } from '../dto/events.dto';
 import { EventsService } from '../services/events.service';
 
+import { LogEvent } from '~modules/events/types';
 import { SessionUserEntity } from '~modules/users/classes/session-user';
 import { SessionUser } from '~shared/decorators/user.decorator';
 import { LoggedInGuard } from '~shared/guards/logged-in.guard';
@@ -19,21 +20,25 @@ export class EventsController {
 	constructor(private eventsService: EventsService) {}
 
 	@Post()
-	public sendEvent(
+	public async sendEvent(
 		@Req() request: Request,
 		@SessionUser() user: SessionUserEntity,
 		@Body() createEventsDto: CreateEventsDto
-	): boolean {
-		const logEvent = {
+	): Promise<boolean> {
+		const logEvent: LogEvent = {
 			id: EventsHelper.getEventId(request),
 			type: createEventsDto.type,
-			source: request.path,
+			source: createEventsDto.path,
 			subject: user.getId(),
 			time: new Date().toISOString(),
 		};
 
+		if (createEventsDto.data) {
+			logEvent.data = createEventsDto.data;
+		}
+
 		// We do not await this one to not let the client wait the response
-		this.eventsService.insertEvents([logEvent]);
+		await this.eventsService.insertEvents([logEvent]);
 
 		return true;
 	}

--- a/src/modules/events/dto/events.dto.ts
+++ b/src/modules/events/dto/events.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEnum, IsString } from 'class-validator';
+import { IsEnum, IsObject, IsString } from 'class-validator';
 
 import { LogEventType } from '../types';
 
@@ -13,8 +13,30 @@ export class CreateEventsDto {
 		description: `Log an event with this type. Possible types: ${Object.values(
 			LogEventType
 		).join(', ')}`,
-		example: LogEventType.USER_AUTHENTICATE,
+		example: LogEventType.ITEM_PLAY,
 		enum: LogEventType,
 	})
 	type: LogEventType;
+
+	@IsString()
+	@ApiProperty({
+		type: String,
+		description: 'The url of the page who triggered the event',
+		example:
+			'https://bezoek-qas.hetarchief.be/or-rf5kf25/0039e1149b7d4d70b165a3ae777ebbf43c41abdd1a674d34be2d2bea08baba875497fb98d4e84239af32a3c3f8a42cc9',
+		required: true,
+	})
+	path: string;
+
+	@IsObject()
+	@ApiProperty({
+		type: Object,
+		description: `Additional information about the event. For instance the video id, or the page url`,
+		example: {
+			schema_identifier:
+				'09f17b37445c4ce59f645c2d5db9dbf8dbee79eba623459caa8c6496108641a0900618cb6ceb4e9b8ad907e47b980ee3',
+		},
+		required: false,
+	})
+	data?: Record<string, unknown>;
 }

--- a/src/modules/events/types.ts
+++ b/src/modules/events/types.ts
@@ -1,16 +1,15 @@
 export enum LogEventType {
 	USER_AUTHENTICATE = 'be.hetarchief.bezoek.user.authenticate',
-	ITEM_VIEW = 'be.hetarchief.bezoek.item.view',
-	ITEM_PLAY = 'be.hetarchief.bezoek.item.play',
+	ITEM_VIEW = 'be.hetarchief.bezoek.item.view', // Triggered in client
+	ITEM_PLAY = 'be.hetarchief.bezoek.item.play', // Triggered in client
 	ITEM_BOOKMARK = 'be.hetarchief.bezoek.item.bookmark',
 	METADATA_EXPORT = 'be.hetarchief.bezoek.metadata.export',
 	VISIT_REQUEST = 'be.hetarchief.bezoek.visit.request',
 	VISIT_REQUEST_APPROVED = 'be.hetarchief.bezoek.visit.approve',
 	VISIT_REQUEST_DENIED = 'be.hetarchief.bezoek.visit.disapprove',
-	VISIT_REQUEST_USE = 'be.hetarchief.bezoek.visit.use', // TODO
 	VISIT_REQUEST_CANCELLED_BY_VISITOR = 'be.hetarchief.bezoek.visit.cancel',
-	VISIT_REQUEST_REVOKED = 'be.hetarchief.bezoek.visit.revoke', // TODO
-	SEARCH = 'be.hetarchief.bezoek.search',
+	VISIT_REQUEST_REVOKED = 'be.hetarchief.bezoek.visit.revoke',
+	SEARCH = 'be.hetarchief.bezoek.search', // Triggered in client
 }
 
 export interface LogEvent {
@@ -19,5 +18,5 @@ export interface LogEvent {
 	source: string;
 	subject: string;
 	time: string; // timestamp
-	data?: any;
+	data?: Record<string, unknown>;
 }

--- a/src/modules/media/media.module.ts
+++ b/src/modules/media/media.module.ts
@@ -6,10 +6,11 @@ import { MediaService } from './services/media.service';
 
 import { PlayerTicketModule } from '~modules/admin/player-ticket/player-ticket.module';
 import { DataModule } from '~modules/data';
+import { EventsModule } from '~modules/events';
 
 @Module({
 	controllers: [MediaController],
-	imports: [ConfigModule, DataModule, PlayerTicketModule],
+	imports: [ConfigModule, DataModule, PlayerTicketModule, EventsModule],
 	providers: [MediaService],
 	exports: [MediaService],
 })


### PR DESCRIPTION
* Add data and path options to the POST /events route
* trigger the metadata export event during export metadata for object and collection

![image](https://user-images.githubusercontent.com/1710840/164214205-1964e888-62dc-40db-9164-d5c409b79884.png)
