### PR TITLE
feat(arc-762): avoid directly overruled notifications

### DIFF
--- a/src/modules/notifications/controllers/notifications.controller.spec.ts
+++ b/src/modules/notifications/controllers/notifications.controller.spec.ts
@@ -99,6 +99,7 @@ const mockNotificationsService: Partial<Record<keyof NotificationsService, jest.
 	create: jest.fn(),
 	update: jest.fn(),
 	updateAll: jest.fn(),
+	simplifyUnreadNotifications: jest.fn(),
 	onCancelVisitRequest: jest.fn(),
 };
 
@@ -164,6 +165,9 @@ describe('NotificationsController', () => {
 		it('should return all notifications for a specific user', async () => {
 			mockNotificationsService.findNotificationsByUser.mockResolvedValueOnce(
 				mockNotificationsResponse
+			);
+			mockNotificationsService.simplifyUnreadNotifications.mockReturnValueOnce(
+				mockNotificationsResponse.items
 			);
 
 			const notifications = await notificationsController.getNotifications(

--- a/src/modules/notifications/controllers/notifications.controller.ts
+++ b/src/modules/notifications/controllers/notifications.controller.ts
@@ -41,6 +41,10 @@ export class NotificationsController {
 			queryDto.page,
 			queryDto.size
 		);
+		notifications.items = await this.notificationsService.simplifyUnreadNotifications(
+			notifications.items,
+			user.getId()
+		);
 		return notifications;
 	}
 

--- a/src/modules/notifications/services/notifications.service.spec.ts
+++ b/src/modules/notifications/services/notifications.service.spec.ts
@@ -470,4 +470,30 @@ describe('NotificationsService', () => {
 			expect(affectedRows).toBe(9);
 		});
 	});
+
+	describe('simplifyUnreadNotifications', () => {
+		it('when both an approved and started notification are unread, it marks the approved one as read', async () => {
+			const notification1 = { ...mockNotification };
+			const notification2 = { ...mockNotification };
+			notification1.type = NotificationType.VISIT_REQUEST_APPROVED;
+			notification2.type = NotificationType.ACCESS_PERIOD_READING_ROOM_STARTED;
+			notification1.status = NotificationStatus.UNREAD;
+			notification2.status = NotificationStatus.UNREAD;
+
+			// mock the update
+			const mockUpdateData: UpdateNotificationMutation = {
+				update_app_notification: {
+					returning: [mockGqlNotification1],
+				},
+			};
+			mockDataService.execute.mockResolvedValueOnce({ data: mockUpdateData });
+
+			const simplifiedNotifications = await notificationsService.simplifyUnreadNotifications(
+				[notification1, notification2],
+				mockUser.id
+			);
+			expect(simplifiedNotifications.length).toBe(2);
+			expect(notification1.status).toEqual(NotificationStatus.READ);
+		});
+	});
 });

--- a/src/modules/notifications/services/notifications.service.ts
+++ b/src/modules/notifications/services/notifications.service.ts
@@ -189,6 +189,30 @@ export class NotificationsService {
 		return affectedRows;
 	}
 
+	public async simplifyUnreadNotifications(
+		notifications: Notification[],
+		userProfileId: string
+	): Promise<Notification[]> {
+		// if a user should receive both the 'approved' and 'started' notification simultaneously, only show the started one
+		const hasApproved = notifications.find(
+			(notification) =>
+				notification.type === NotificationType.VISIT_REQUEST_APPROVED &&
+				notification.status === NotificationStatus.UNREAD
+		);
+		const hasStarted = notifications.find(
+			(notification) =>
+				notification.type === NotificationType.ACCESS_PERIOD_READING_ROOM_STARTED &&
+				notification.status === NotificationStatus.UNREAD
+		);
+
+		if (hasApproved && hasStarted) {
+			hasApproved.status = NotificationStatus.READ;
+			await this.update(hasApproved.id, userProfileId, { status: NotificationStatus.READ });
+		}
+
+		return notifications;
+	}
+
 	/**
 	 * Send notifications and email on new visit request
 	 */


### PR DESCRIPTION
In case when a user should receive both the 'approved' and 'started' notification simultaneously, the 'approved' notification is automatically marked as read, so the users only sees the 'started' toast notification.
The approved notification is still in the list but marked as read -- or should the notification be deleted?