### PR TITLE
fix(arc-213): Only add where object if query is defined

### DIFF
--- a/src/modules/collections/dto/collections.dto.spec.ts
+++ b/src/modules/collections/dto/collections.dto.spec.ts
@@ -15,7 +15,7 @@ describe('CollectionsDto', () => {
 			const collectionObjectsQueryDto = new CollectionObjectsQueryDto();
 			expect(collectionObjectsQueryDto).toEqual({
 				page: 1,
-				query: '%',
+				query: undefined,
 				size: 10,
 			});
 		});

--- a/src/modules/collections/dto/collections.dto.ts
+++ b/src/modules/collections/dto/collections.dto.ts
@@ -19,10 +19,10 @@ export class CollectionObjectsQueryDto {
 	@IsOptional()
 	@ApiPropertyOptional({
 		type: String,
-		description: "The query to search for. Use '%' for wildcard.",
-		default: '%',
+		description: "The query to search for. Use '%queryTerm%' for wildcard.",
+		default: undefined,
 	})
-	query? = '%';
+	query? = undefined;
 
 	@IsNumber()
 	@Type(() => Number)

--- a/src/modules/collections/services/collections.service.ts
+++ b/src/modules/collections/services/collections.service.ts
@@ -172,15 +172,18 @@ export class CollectionsService {
 	): Promise<IPagination<IeObject>> {
 		const { query, page, size } = queryDto;
 		const { offset, limit } = PaginationHelper.convertPagination(page, size);
-		const where = {
-			_or: [
-				{ ie: { schema_name: { _ilike: query } } },
-				{ ie: { maintainer: { schema_name: { _ilike: query } } } },
-				{ ie: { dcterms_format: { _ilike: query } } },
-				{ ie: { meemoo_identifier: { _ilike: query } } },
-				{ ie: { schema_identifier: { _ilike: query } } },
-			],
-		};
+		let where = {};
+		if (query) {
+			where = {
+				_or: [
+					{ ie: { schema_name: { _ilike: query } } },
+					{ ie: { maintainer: { schema_name: { _ilike: query } } } },
+					{ ie: { dcterms_format: { _ilike: query } } },
+					{ ie: { meemoo_identifier: { _ilike: query } } },
+					{ ie: { schema_identifier: { _ilike: query } } },
+				],
+			};
+		}
 		const collectionObjectsResponse =
 			await this.dataService.execute<FindCollectionObjectsByCollectionIdQuery>(
 				FindCollectionObjectsByCollectionIdDocument,


### PR DESCRIPTION
Related PR: https://github.com/viaacode/hetarchief-client/pull/312

This avoids queries like this:
```json
{
  "collectionId": "c76d3cbc-6743-428b-b74c-e682f6c7ceee",
  "userProfileId": "bee33872-2823-42a4-a619-2089ae145af3",
  "where": {
    "_or": [
      {
        "ie": {
          "schema_name": {
            "_ilike": "%%"
          }
        }
      },
      {
        "ie": {
          "maintainer": {
            "schema_name": {
              "_ilike": "%%"
            }
          }
        }
      },
      {
        "ie": {
          "dcterms_format": {
            "_ilike": "%%"
          }
        }
      },
      {
        "ie": {
          "meemoo_identifier": {
            "_ilike": "%%"
          }
        }
      },
      {
        "ie": {
          "schema_identifier": {
            "_ilike": "%%"
          }
        }
      }
    ]
  },
  "offset": 0,
  "limit": 20
}
```