### PR TITLE
fix(arc-611): Fix issues with content page overview route

### DIFF
--- a/src/modules/admin/content-pages/controllers/content-pages.controller.ts
+++ b/src/modules/admin/content-pages/controllers/content-pages.controller.ts
@@ -13,12 +13,15 @@ import {
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { IPagination } from '@studiohyperdrive/pagination';
-import { get, intersection } from 'lodash';
+import { compact, get, intersection } from 'lodash';
 
 import { ContentPage, LabelObj } from '../content-pages.types';
 
 import { ContentLabelsRequestDto } from '~modules/admin/content-pages/dto/content-labels-request.dto';
-import { ContentPagesQueryDto } from '~modules/admin/content-pages/dto/content-pages.dto';
+import {
+	ContentPageOverviewParams,
+	ContentPagesQueryDto,
+} from '~modules/admin/content-pages/dto/content-pages.dto';
 import { ResolveMediaGridBlocksDto } from '~modules/admin/content-pages/dto/resolve-media-grid-blocks.dto';
 import { ContentPagesService } from '~modules/admin/content-pages/services/content-pages.service';
 import { SessionUserEntity } from '~modules/users/classes/session-user';
@@ -27,6 +30,7 @@ import { SessionHelper } from '~shared/auth/session-helper';
 import { SessionUser } from '~shared/decorators/user.decorator';
 import { ApiKeyGuard } from '~shared/guards/api-key.guard';
 import { LoggedInGuard } from '~shared/guards/logged-in.guard';
+import { SpecialPermissionGroups } from '~shared/types/types';
 
 @UseGuards(LoggedInGuard)
 @ApiTags('ContentPages')
@@ -38,9 +42,18 @@ export class ContentPagesController {
 
 	@Post('overview')
 	public async getContentPagesForOverview(
-		@Query() queryDto: ContentPagesQueryDto
+		@Body() queryDto: ContentPageOverviewParams,
+		@SessionUser() user?: SessionUserEntity
 	): Promise<IPagination<ContentPage>> {
-		const contentPages = await this.contentPagesService.getContentPagesForOverview(queryDto);
+		const contentPages = await this.contentPagesService.getContentPagesForOverview(
+			queryDto,
+			compact([
+				user?.getUser()?.groupId,
+				user
+					? SpecialPermissionGroups.loggedInUsers
+					: SpecialPermissionGroups.loggedOutUsers,
+			])
+		);
 		return contentPages;
 	}
 

--- a/src/modules/admin/content-pages/dto/content-pages.dto.ts
+++ b/src/modules/admin/content-pages/dto/content-pages.dto.ts
@@ -1,4 +1,4 @@
-import { ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform, Type } from 'class-transformer';
 import { IsArray, IsBoolean, IsNumber, IsObject, IsOptional, IsString } from 'class-validator';
 
@@ -214,4 +214,114 @@ export class ContentPagesQueryDto {
 		enum: SortDirection,
 	})
 	orderDirection? = SortDirection.asc;
+}
+
+export class ContentPageOverviewParams {
+	@IsBoolean()
+	@Type(() => Boolean)
+	@IsOptional()
+	@ApiPropertyOptional({
+		type: Boolean,
+		description: 'Also include the content blocks for each page',
+		default: false,
+	})
+	withBlock? = false;
+
+	@IsString()
+	@ApiProperty({
+		type: String,
+		description: 'Type of the content pages you want to fetch. eg: PAGINA, FAQ_ITEM, ...',
+		example: 'FAQ_ITEM',
+	})
+	contentType: string;
+
+	@IsArray()
+	@IsOptional()
+	@Transform(commaSeparatedStringToArray)
+	@ApiPropertyOptional({
+		type: String,
+		description:
+			'Visible tabs in the page overview component for which we should fetch item counts',
+		required: false,
+		example: ['69ccef3b-751a-4be4-95bc-5ef365fbd504'],
+	})
+	labelIds?: string[];
+
+	@IsArray()
+	@IsOptional()
+	@Transform(commaSeparatedStringToArray)
+	@ApiPropertyOptional({
+		type: String,
+		description: 'Selected tabs for which we should fetch content page items',
+		required: false,
+		example: ['69ccef3b-751a-4be4-95bc-5ef365fbd504'],
+	})
+	selectedLabelIds?: string[];
+
+	@IsString()
+	@Type(() => String)
+	@IsOptional()
+	@ApiPropertyOptional({
+		type: String,
+		description: 'property to sort the results by',
+		default: 'title_lower',
+		enum: [
+			'id',
+			'title',
+			'description',
+			'is_public',
+			'publish_at',
+			'depublish_at',
+			'created_at',
+			'updated_at',
+			'is_protected',
+			'content_type',
+			'user_profile_id',
+			'path',
+			'user_group_ids',
+			'content_width',
+			'thumbnail_path',
+			'header_path',
+			'seo_title',
+			'seo_description',
+			'seo_keywords',
+			'published_at',
+			'meta_description',
+			'updated_by_profile_id',
+			'is_deleted',
+			'seo_image_path',
+		],
+	})
+	orderProp? = 'title';
+
+	@IsString()
+	@Type(() => String)
+	@IsOptional()
+	@ApiPropertyOptional({
+		type: String,
+		description: 'Direction to sort in. either desc or asc',
+		default: SortDirection.asc,
+		enum: SortDirection,
+	})
+	orderDirection? = SortDirection.asc;
+
+	@IsNumber()
+	@Type(() => Number)
+	@IsOptional()
+	@ApiPropertyOptional({
+		type: Number,
+		description: 'Which page of results to fetch. Counting starts at 1',
+		default: 1,
+	})
+	page? = 1;
+
+	@IsNumber()
+	@Type(() => Number)
+	@IsOptional()
+	@ApiPropertyOptional({
+		type: Number,
+		description: 'The max. number of results to return',
+		default: 10,
+	})
+	size? = 10;
 }


### PR DESCRIPTION
* The route itself wasn't correcte migrated from avo to hetarchief
* paging is anders
* user groups are now strings

required to get the admin-core to work for testing:
![image](https://user-images.githubusercontent.com/1710840/169816504-44e34cf0-3107-400b-9e46-9baa47b15979.png)
