### PR TITLE
fix(arc-957): text search should only match with one strategy, not all

### DIFF
--- a/src/modules/media/elasticsearch/queryBuilder.spec.ts
+++ b/src/modules/media/elasticsearch/queryBuilder.spec.ts
@@ -115,7 +115,7 @@ describe('QueryBuilder', () => {
 				size: 10,
 				page: 1,
 			});
-			expect(esQuery.query.bool.must[0].multi_match.fields).not.toContain(
+			expect(esQuery.query.bool.must[0].bool.should[0].multi_match.fields).not.toContain(
 				'schema_transcript'
 			);
 		});

--- a/src/modules/media/elasticsearch/queryBuilder.spec.ts
+++ b/src/modules/media/elasticsearch/queryBuilder.spec.ts
@@ -78,7 +78,7 @@ describe('QueryBuilder', () => {
 				size: 10,
 				page: 1,
 			});
-			expect(esQuery.query.bool.must.length).toBeGreaterThanOrEqual(2);
+			expect(esQuery.query.bool.must[0].bool.should.length).toBeGreaterThanOrEqual(2);
 		});
 
 		it('should return an empty query when empty query filter is specified', () => {

--- a/src/modules/media/elasticsearch/queryBuilder.ts
+++ b/src/modules/media/elasticsearch/queryBuilder.ts
@@ -164,7 +164,14 @@ export class QueryBuilder {
 			_.set(matchObj, 'multi_match.query', escapedQueryString);
 		});
 
-		return textQueryFilterArray;
+		return [
+			{
+				bool: {
+					should: textQueryFilterArray,
+					minimum_should_match: 1, // At least one of the search patterns has to match, but not all of them
+				},
+			},
+		];
 	}
 
 	/**


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-957

before: (linked to prod elasticsearch)
![image](https://user-images.githubusercontent.com/1710840/173011058-dbcb1405-a26e-4be8-a80f-3368c5b3df2a.png)

after: (linked to prod elasticsearch)
![image](https://user-images.githubusercontent.com/1710840/173011087-ed959969-5d11-48af-be1c-fd3e21b43d7f.png)

