### PR TITLE
fix(test): improve jest execution speed on windows

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -24,4 +24,9 @@ module.exports = {
 	},
 	setupFilesAfterEnv: ['../jest.setup.redis-mock.ts'],
 	coveragePathIgnorePatterns: ['node_modules', '.module.ts', '.dto.ts', 'index.ts'],
+	globals: {
+		'ts-jest': {
+			isolatedModules: true,
+		},
+	},
 };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --cache",
     "lint:fix": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "format:fix": "prettier --write \"src/**/*.ts\" \"src/**/*.graphql\" \"!src/generated/**/*.ts\"",
-    "test": "jest",
+    "test": "jest --maxWorkers=8",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",


### PR DESCRIPTION
reduces test execution time from 88 seconds to 28 seconds