### PR TITLE
fix(arc-1604): fix text search and consultable filters + add tests

### DIFF
--- a/src/modules/ie-objects/dto/ie-objects.dto.ts
+++ b/src/modules/ie-objects/dto/ie-objects.dto.ts
@@ -3,21 +3,25 @@ import { Transform, Type } from 'class-transformer';
 import { IsArray, IsEnum, IsNumber, IsOptional, IsString, ValidateNested } from 'class-validator';
 import { isArray } from 'lodash';
 
-import { Operator, OrderProperty, SearchFilterField } from '../elasticsearch/elasticsearch.consts';
+import {
+	IeObjectsSearchFilterField,
+	Operator,
+	OrderProperty,
+} from '../elasticsearch/elasticsearch.consts';
 
 import { commaSeparatedStringToArray } from '~shared/helpers/comma-separated-string-to-array';
 import { SortDirection } from '~shared/types';
 
 export class SearchFilter {
 	@IsString()
-	@IsEnum(SearchFilterField)
+	@IsEnum(IeObjectsSearchFilterField)
 	@ApiProperty({
 		type: String,
-		description: `The field to filter on. Options are: ${Object.values(SearchFilterField).join(
-			', '
-		)}`,
+		description: `The field to filter on. Options are: ${Object.values(
+			IeObjectsSearchFilterField
+		).join(', ')}`,
 	})
-	field: SearchFilterField;
+	field: IeObjectsSearchFilterField;
 
 	@IsArray()
 	@IsOptional()
@@ -82,13 +86,13 @@ export class IeObjectsQueryDto {
 
 	@IsArray()
 	@IsOptional()
-	@IsEnum(SearchFilterField, { each: true })
+	@IsEnum(IeObjectsSearchFilterField, { each: true })
 	@ApiPropertyOptional({
 		type: Array,
 		description: 'The aggregates to include in the result',
 		default: [],
 	})
-	requestedAggs?: SearchFilterField[];
+	requestedAggs?: IeObjectsSearchFilterField[];
 
 	@IsString()
 	@IsEnum(OrderProperty)

--- a/src/modules/ie-objects/elasticsearch/elasticsearch.consts.ts
+++ b/src/modules/ie-objects/elasticsearch/elasticsearch.consts.ts
@@ -21,7 +21,7 @@ const descriptionSearchQueryTemplateFuzzy = _.values(descriptionSearchQueryFuzzy
 const nameSearchQueryTemplateExact = _.values(nameSearchQueryExact);
 const identifierSearchQueryTemplateExact = _.values(identifierSearchQueryFuzzy);
 
-export enum SearchFilterField {
+export enum IeObjectsSearchFilterField {
 	QUERY = 'query',
 	ADVANCED_QUERY = 'advancedQuery',
 	GENRE = 'genre',
@@ -45,7 +45,7 @@ export enum SearchFilterField {
 	DURATION = 'duration',
 	LANGUAGE = 'language',
 	MEDIUM = 'medium',
-	CONSULTABLE_REMOTE = 'isConsultableRemote',
+	CONSULTABLE_ONLY_ON_LOCATION = 'isConsultableOnlyOnLocation',
 	CONSULTABLE_MEDIA = 'isConsultableMedia',
 	TYPE = 'type',
 }
@@ -95,53 +95,32 @@ export const MULTI_MATCH_QUERY_MAPPING = {
 	exact: {
 		name: nameSearchQueryTemplateExact,
 		identifier: identifierSearchQueryTemplateExact,
-		exactQuery: searchQueryTemplateExact,
+		query: searchQueryTemplateExact,
 	},
 };
 
-export interface QueryBuilderConfig {
-	AGGS_PROPERTIES: Array<SearchFilterField>;
-	MAX_COUNT_SEARCH_RESULTS: number;
-	MAX_NUMBER_SEARCH_RESULTS: number;
-	NEEDS_FILTER_SUFFIX: { [prop in SearchFilterField]?: string };
-	NUMBER_OF_FILTER_OPTIONS: number;
-	READABLE_TO_ELASTIC_FILTER_NAMES: { [prop in SearchFilterField]?: string };
-	DEFAULT_QUERY_TYPE: { [prop in SearchFilterField]?: QueryType };
-	OCCURRENCE_TYPE: { [prop in Operator]?: string };
-	VALUE_OPERATORS: Array<Operator>;
-	ORDER_MAPPINGS: { [prop in OrderProperty]: string };
-	MULTI_MATCH_FIELDS: Array<SearchFilterField>;
-	MULTI_MATCH_QUERY_MAPPING: typeof MULTI_MATCH_QUERY_MAPPING;
-	NEEDS_AGG_SUFFIX: { [prop in SearchFilterField]?: string };
-}
-
-export const DEFAULT_QUERY_TYPE: { [prop in SearchFilterField]?: QueryType } = {
-	[SearchFilterField.GENRE]: QueryType.TERMS, // text // TODO es text -> can be match query: no longer case sensitive but issue with multiValue
-	[SearchFilterField.KEYWORD]: QueryType.TERMS, // text // TODO es text -> can be match query: no longer case sensitive but issue with multiValue
-	[SearchFilterField.NAME]: QueryType.TERM, // used for exact (not) matching
-	[SearchFilterField.FORMAT]: QueryType.TERMS, // es keyword
-	[SearchFilterField.PUBLISHER]: QueryType.TERMS,
-	[SearchFilterField.CREATOR]: QueryType.TERMS,
-	[SearchFilterField.CREATED]: QueryType.RANGE,
-	[SearchFilterField.PUBLISHED]: QueryType.RANGE,
-	[SearchFilterField.DESCRIPTION]: QueryType.TERM, // used for exact (not) matching
-	[SearchFilterField.ERA]: QueryType.MATCH,
-	[SearchFilterField.LOCATION]: QueryType.MATCH,
-	[SearchFilterField.MAINTAINER_ID]: QueryType.TERMS,
-	[SearchFilterField.MAINTAINER_NAME]: QueryType.TERMS,
-	[SearchFilterField.CAST]: QueryType.TERMS,
-	[SearchFilterField.CAPTION]: QueryType.TERM,
-	[SearchFilterField.TRANSCRIPT]: QueryType.TERM,
-	[SearchFilterField.CATEGORIE]: QueryType.TERMS,
-	[SearchFilterField.DURATION]: QueryType.RANGE,
-	[SearchFilterField.LANGUAGE]: QueryType.TERMS,
-	[SearchFilterField.MEDIUM]: QueryType.TERMS,
+export const DEFAULT_QUERY_TYPE: { [prop in IeObjectsSearchFilterField]?: QueryType } = {
+	[IeObjectsSearchFilterField.GENRE]: QueryType.TERMS, // text // TODO es text -> can be match query: no longer case sensitive but issue with multiValue
+	[IeObjectsSearchFilterField.KEYWORD]: QueryType.TERMS, // text // TODO es text -> can be match query: no longer case sensitive but issue with multiValue
+	[IeObjectsSearchFilterField.NAME]: QueryType.TERM, // used for exact (not) matching
+	[IeObjectsSearchFilterField.FORMAT]: QueryType.TERMS, // es keyword
+	[IeObjectsSearchFilterField.PUBLISHER]: QueryType.TERMS,
+	[IeObjectsSearchFilterField.CREATOR]: QueryType.TERMS,
+	[IeObjectsSearchFilterField.CREATED]: QueryType.RANGE,
+	[IeObjectsSearchFilterField.PUBLISHED]: QueryType.RANGE,
+	[IeObjectsSearchFilterField.DESCRIPTION]: QueryType.TERM, // used for exact (not) matching
+	[IeObjectsSearchFilterField.ERA]: QueryType.MATCH,
+	[IeObjectsSearchFilterField.LOCATION]: QueryType.MATCH,
+	[IeObjectsSearchFilterField.MAINTAINER_ID]: QueryType.TERMS,
+	[IeObjectsSearchFilterField.MAINTAINER_NAME]: QueryType.TERMS,
+	[IeObjectsSearchFilterField.CAST]: QueryType.TERMS,
+	[IeObjectsSearchFilterField.CAPTION]: QueryType.TERM,
+	[IeObjectsSearchFilterField.TRANSCRIPT]: QueryType.TERM,
+	[IeObjectsSearchFilterField.CATEGORIE]: QueryType.TERMS,
+	[IeObjectsSearchFilterField.DURATION]: QueryType.RANGE,
+	[IeObjectsSearchFilterField.LANGUAGE]: QueryType.TERMS,
+	[IeObjectsSearchFilterField.MEDIUM]: QueryType.TERMS,
 };
-
-export interface QueryBuilderConsultableFilters {
-	isConsultableRemote: boolean;
-	isConsultableMedia: boolean;
-}
 
 // Max number of search results to return to the client
 export const MAX_NUMBER_SEARCH_RESULTS = 2000;
@@ -153,31 +132,35 @@ export const MAX_COUNT_SEARCH_RESULTS = 10000;
 export const NUMBER_OF_FILTER_OPTIONS = 40;
 
 export const READABLE_TO_ELASTIC_FILTER_NAMES: {
-	[prop in Exclude<SearchFilterField, 'isConsultableRemote' | 'isConsultableMedia'>]: string;
+	[prop in Exclude<
+		IeObjectsSearchFilterField,
+		| IeObjectsSearchFilterField.CONSULTABLE_ONLY_ON_LOCATION
+		| IeObjectsSearchFilterField.CONSULTABLE_MEDIA
+	>]: string;
 } = {
-	[SearchFilterField.QUERY]: 'query',
-	[SearchFilterField.ADVANCED_QUERY]: 'query',
-	[SearchFilterField.GENRE]: 'schema_genre',
-	[SearchFilterField.KEYWORD]: 'schema_keywords',
-	[SearchFilterField.NAME]: 'schema_name',
-	[SearchFilterField.FORMAT]: 'dcterms_format',
-	[SearchFilterField.PUBLISHER]: 'schema_publisher',
-	[SearchFilterField.CREATOR]: 'schema_creator',
-	[SearchFilterField.CREATED]: 'schema_date_created',
-	[SearchFilterField.PUBLISHED]: 'schema_date_published',
-	[SearchFilterField.DESCRIPTION]: 'schema_description',
-	[SearchFilterField.ERA]: 'schema_temporal_coverage',
-	[SearchFilterField.LOCATION]: 'schema_spatial_coverage',
-	[SearchFilterField.MAINTAINER_ID]: 'schema_maintainer.schema_identifier',
-	[SearchFilterField.MAINTAINER_NAME]: 'schema_maintainer.schema_name',
-	[SearchFilterField.CAST]: 'meemoo_description_cast',
-	[SearchFilterField.CAPTION]: 'schema_caption',
-	[SearchFilterField.TRANSCRIPT]: 'schema_transcript',
-	[SearchFilterField.CATEGORIE]: 'meemoo_description_categorie',
-	[SearchFilterField.DURATION]: 'schema_duration',
-	[SearchFilterField.LANGUAGE]: 'schema_in_language',
-	[SearchFilterField.MEDIUM]: 'dcterms_medium',
-	[SearchFilterField.TYPE]: 'ebucore_object_type',
+	[IeObjectsSearchFilterField.QUERY]: 'query',
+	[IeObjectsSearchFilterField.ADVANCED_QUERY]: 'query',
+	[IeObjectsSearchFilterField.GENRE]: 'schema_genre',
+	[IeObjectsSearchFilterField.KEYWORD]: 'schema_keywords',
+	[IeObjectsSearchFilterField.NAME]: 'schema_name',
+	[IeObjectsSearchFilterField.FORMAT]: 'dcterms_format',
+	[IeObjectsSearchFilterField.PUBLISHER]: 'schema_publisher',
+	[IeObjectsSearchFilterField.CREATOR]: 'schema_creator',
+	[IeObjectsSearchFilterField.CREATED]: 'schema_date_created',
+	[IeObjectsSearchFilterField.PUBLISHED]: 'schema_date_published',
+	[IeObjectsSearchFilterField.DESCRIPTION]: 'schema_description',
+	[IeObjectsSearchFilterField.ERA]: 'schema_temporal_coverage',
+	[IeObjectsSearchFilterField.LOCATION]: 'schema_spatial_coverage',
+	[IeObjectsSearchFilterField.MAINTAINER_ID]: 'schema_maintainer.schema_identifier',
+	[IeObjectsSearchFilterField.MAINTAINER_NAME]: 'schema_maintainer.schema_name',
+	[IeObjectsSearchFilterField.CAST]: 'meemoo_description_cast',
+	[IeObjectsSearchFilterField.CAPTION]: 'schema_caption',
+	[IeObjectsSearchFilterField.TRANSCRIPT]: 'schema_transcript',
+	[IeObjectsSearchFilterField.CATEGORIE]: 'meemoo_description_categorie',
+	[IeObjectsSearchFilterField.DURATION]: 'schema_duration',
+	[IeObjectsSearchFilterField.LANGUAGE]: 'schema_in_language',
+	[IeObjectsSearchFilterField.MEDIUM]: 'dcterms_medium',
+	[IeObjectsSearchFilterField.TYPE]: 'ebucore_object_type',
 };
 
 export const ORDER_MAPPINGS: { [prop in OrderProperty]: string } = {
@@ -187,11 +170,11 @@ export const ORDER_MAPPINGS: { [prop in OrderProperty]: string } = {
 	name: 'schema_name.keyword',
 };
 
-export const MULTI_MATCH_FIELDS: Array<SearchFilterField> = [
-	SearchFilterField.QUERY,
-	SearchFilterField.ADVANCED_QUERY,
-	SearchFilterField.NAME,
-	SearchFilterField.DESCRIPTION,
+export const MULTI_MATCH_FIELDS: Array<IeObjectsSearchFilterField> = [
+	IeObjectsSearchFilterField.QUERY,
+	IeObjectsSearchFilterField.ADVANCED_QUERY,
+	IeObjectsSearchFilterField.NAME,
+	IeObjectsSearchFilterField.DESCRIPTION,
 ];
 
 export const OCCURRENCE_TYPE: { [prop in Operator]?: string } = {
@@ -204,17 +187,19 @@ export const OCCURRENCE_TYPE: { [prop in Operator]?: string } = {
 export const VALUE_OPERATORS: Operator[] = [Operator.GTE, Operator.LTE];
 
 // By default add the 'format' aggregation
-export const AGGS_PROPERTIES: Array<SearchFilterField> = [SearchFilterField.FORMAT];
+export const AGGS_PROPERTIES: Array<IeObjectsSearchFilterField> = [
+	IeObjectsSearchFilterField.FORMAT,
+];
 
-export const NEEDS_FILTER_SUFFIX: { [prop in SearchFilterField]?: string } = {
-	[SearchFilterField.GENRE]: 'keyword',
-	[SearchFilterField.NAME]: 'keyword',
-	[SearchFilterField.MAINTAINER_NAME]: 'keyword',
-	[SearchFilterField.TYPE]: 'keyword',
+export const NEEDS_FILTER_SUFFIX: { [prop in IeObjectsSearchFilterField]?: string } = {
+	[IeObjectsSearchFilterField.GENRE]: 'keyword',
+	[IeObjectsSearchFilterField.NAME]: 'keyword',
+	[IeObjectsSearchFilterField.MAINTAINER_NAME]: 'keyword',
+	[IeObjectsSearchFilterField.TYPE]: 'keyword',
 };
 
-export const NEEDS_AGG_SUFFIX: { [prop in SearchFilterField]?: string } = {
-	[SearchFilterField.GENRE]: 'keyword',
-	[SearchFilterField.MAINTAINER_NAME]: 'keyword',
-	[SearchFilterField.TYPE]: 'keyword',
+export const NEEDS_AGG_SUFFIX: { [prop in IeObjectsSearchFilterField]?: string } = {
+	[IeObjectsSearchFilterField.GENRE]: 'keyword',
+	[IeObjectsSearchFilterField.MAINTAINER_NAME]: 'keyword',
+	[IeObjectsSearchFilterField.TYPE]: 'keyword',
 };

--- a/src/modules/ie-objects/elasticsearch/queryBuilder.ts
+++ b/src/modules/ie-objects/elasticsearch/queryBuilder.ts
@@ -3,13 +3,17 @@ import jsep from 'jsep';
 import { clamp, forEach, isArray, isEmpty, isNil, set } from 'lodash';
 
 import { IeObjectsQueryDto, SearchFilter } from '../dto/ie-objects.dto';
-import { convertNodeToEsQueryFilterObjects } from '../helpers/convert-node-to-es-query-filter-objects';
+import {
+	buildFreeTextFilter,
+	convertNodeToEsQueryFilterObjects,
+} from '../helpers/convert-node-to-es-query-filter-objects';
 import { getSectorsWithEssenceAccess } from '../helpers/get-sectors-with-essence-access';
 import { IeObjectLicense } from '../ie-objects.types';
 
 import {
 	AGGS_PROPERTIES,
 	DEFAULT_QUERY_TYPE,
+	IeObjectsSearchFilterField,
 	MAX_COUNT_SEARCH_RESULTS,
 	MAX_NUMBER_SEARCH_RESULTS,
 	MULTI_MATCH_FIELDS,
@@ -21,11 +25,9 @@ import {
 	Operator,
 	ORDER_MAPPINGS,
 	OrderProperty,
-	QueryBuilderConsultableFilters,
 	QueryBuilderInputInfo,
 	QueryType,
 	READABLE_TO_ELASTIC_FILTER_NAMES,
-	SearchFilterField,
 	VALUE_OPERATORS,
 } from './elasticsearch.consts';
 
@@ -189,6 +191,7 @@ export class QueryBuilder {
 	 * Creates the filter portion of the elasticsearch query object
 	 * Containing the search terms and the checked filters
 	 * @param filters
+	 * @param inputInfo
 	 */
 	private static buildFilterObject(
 		filters: SearchFilter[] | undefined,
@@ -207,9 +210,9 @@ export class QueryBuilder {
 		// Determine consultable filters are present and strip them from standard filter list to be processed later on
 		// Remark: this needs to happen after the line that checks if filters are empty.
 		// This because if we strip it before it will just return match_all
-		const consultableSearchFilterFields: SearchFilterField[] = [
-			SearchFilterField.CONSULTABLE_REMOTE,
-			SearchFilterField.CONSULTABLE_MEDIA,
+		const consultableSearchFilterFields: IeObjectsSearchFilterField[] = [
+			IeObjectsSearchFilterField.CONSULTABLE_ONLY_ON_LOCATION,
+			IeObjectsSearchFilterField.CONSULTABLE_MEDIA,
 		];
 		if (
 			filters &&
@@ -223,7 +226,7 @@ export class QueryBuilder {
 			consultableFilters.forEach((consultableFilter) =>
 				this.applyFilter(filterObject, consultableFilter)
 			);
-			// Remove CONSULTABLE_REMOTE and CONSULTABLE_MEDIA filter entries from the filter list,
+			// Remove CONSULTABLE_ONLY_ON_LOCATION and CONSULTABLE_MEDIA filter entries from the filter list,
 			// since they have been handled above and should not be handled by the standard field filtering logic.
 			filters = filters.filter(
 				(filter: SearchFilter) => !consultableSearchFilterFields.includes(filter.field)
@@ -242,19 +245,21 @@ export class QueryBuilder {
 				if (this.isFuzzyOperator(searchFilter.operator)) {
 					// Use a multi field search template to fuzzy search in elasticsearch across multiple fields
 
-					const searchTemplate = MULTI_MATCH_QUERY_MAPPING.fuzzy[searchFilter.field];
-
 					let textFilters;
-					if (searchFilter.field === SearchFilterField.QUERY) {
+					if (searchFilter.field === IeObjectsSearchFilterField.QUERY) {
 						textFilters = [
 							convertNodeToEsQueryFilterObjects(
 								jsep(searchFilter.value),
-								MULTI_MATCH_QUERY_MAPPING.exact.exactQuery,
+								{
+									fuzzy: MULTI_MATCH_QUERY_MAPPING.fuzzy.query,
+									exact: MULTI_MATCH_QUERY_MAPPING.exact.query,
+								},
 								searchFilter
 							),
 						];
 					} else {
-						textFilters = this.buildFreeTextFilter(searchTemplate, searchFilter);
+						const searchTemplate = MULTI_MATCH_QUERY_MAPPING.fuzzy[searchFilter.field];
+						textFilters = [buildFreeTextFilter(searchTemplate, searchFilter)];
 					}
 
 					textFilters.forEach((filter) =>
@@ -274,14 +279,12 @@ export class QueryBuilder {
 						);
 					}
 
-					const textFilters = this.buildFreeTextFilter(searchTemplate, searchFilter);
+					const textFilter = buildFreeTextFilter(searchTemplate, searchFilter);
 
-					textFilters.forEach((filter) =>
-						this.applyFilter(filterObject, {
-							occurrenceType: this.getOccurrenceType(searchFilter.operator),
-							query: filter,
-						})
-					);
+					this.applyFilter(filterObject, {
+						occurrenceType: this.getOccurrenceType(searchFilter.operator),
+						query: textFilter,
+					});
 					return;
 				}
 			}
@@ -291,9 +294,10 @@ export class QueryBuilder {
 			 */
 			if (
 				MULTI_MATCH_FIELDS.includes(searchFilter.field) &&
-				[SearchFilterField.ADVANCED_QUERY, SearchFilterField.QUERY].includes(
-					searchFilter.field
-				)
+				[
+					IeObjectsSearchFilterField.ADVANCED_QUERY,
+					IeObjectsSearchFilterField.QUERY,
+				].includes(searchFilter.field)
 			) {
 				throw new BadRequestException(
 					`Field '${searchFilter.field}' cannot be queried with the '${searchFilter.operator}' operator.`
@@ -319,40 +323,27 @@ export class QueryBuilder {
 	 *	This function checks if the isConsultableFilters are present in the searchRequestFilters and returns the correct filter objects
 	 *
 	 * @param searchRequestFilters
-	 * @returns { isConsultableRemote: boolean, isConsultableMedia: boolean }
+	 * @param inputInfo
+	 * @returns
 	 */
 	public static determineIsConsultableFilters(
 		searchRequestFilters: SearchFilter[],
 		inputInfo: QueryBuilderInputInfo
 	): any {
 		const toBeAppliedConsultableFilters: any = [];
-		const consultableFilters: QueryBuilderConsultableFilters = {
-			isConsultableRemote: isEmpty(
-				searchRequestFilters.filter(
-					(filter: SearchFilter) => filter.field === SearchFilterField.CONSULTABLE_REMOTE
-				)
-			)
-				? // if FE does not return isConsultableRemote filter by default it will be visible both onSite and Remote
-				  // However for 99,99% of the time this will never happen
-				  true
-				: // Value from query string will be string but we need a Boolean
-				  searchRequestFilters[0]?.value?.toLowerCase() === 'true',
-			isConsultableMedia: isEmpty(
-				searchRequestFilters.filter(
-					(filter: SearchFilter) => filter.field === SearchFilterField.CONSULTABLE_MEDIA
-				)
-			)
-				? // if FE does not return isConsultableMedia filter by default the essence will not be consultable
-				  // However for 99,99% of the time this will never happen
-				  false
-				: // Value from query string will be string but we need a Boolean
-				  searchRequestFilters[0]?.value?.toLowerCase() === 'true',
-		};
+
+		const consultableOnlyOnLocationFilter = searchRequestFilters.find(
+			(filter: SearchFilter) =>
+				filter.field === IeObjectsSearchFilterField.CONSULTABLE_ONLY_ON_LOCATION
+		);
+		const consultableMediaFilter = searchRequestFilters.find(
+			(filter: SearchFilter) => filter.field === IeObjectsSearchFilterField.CONSULTABLE_MEDIA
+		);
 
 		// add consultable filters
 		// This filter is inverted, so we only run the filter if the value is false. Don't run it if the value is undefined/null
 		if (
-			consultableFilters.isConsultableRemote === false &&
+			consultableOnlyOnLocationFilter?.value?.toLowerCase() === 'true' &&
 			inputInfo.user.getGroupId() !== GroupId.KIOSK_VISITOR
 		) {
 			toBeAppliedConsultableFilters.push({
@@ -375,10 +366,10 @@ export class QueryBuilder {
 
 		// User can access anything in combo with
 		// Object has VIAA_INTRA_CP-CONTENT license
-		// ACM: user has catpro
+		// ACM: user has catpro (key user)
 		// ACM: sector or id the user connected to
 		if (
-			consultableFilters.isConsultableMedia &&
+			consultableMediaFilter?.value?.toLowerCase() === 'true' &&
 			inputInfo.user.getIsKeyUser() &&
 			!isNil(inputInfo.user.getSector())
 		) {
@@ -555,24 +546,6 @@ export class QueryBuilder {
 		};
 	}
 
-	protected static buildFreeTextFilter(searchTemplate: any[], searchFilter: SearchFilter): any {
-		// Replace {{query}} in the template with the escaped search terms
-		let stringifiedSearchTemplate = JSON.stringify(searchTemplate);
-		stringifiedSearchTemplate = stringifiedSearchTemplate.replace(
-			/\{\{query\}\}/g,
-			searchFilter.value
-		);
-
-		return [
-			{
-				bool: {
-					should: JSON.parse(stringifiedSearchTemplate),
-					minimum_should_match: 1, // At least one of the search patterns has to match, but not all of them
-				},
-			},
-		];
-	}
-
 	protected static applyFilter(filterObject: any, newFilter: any): void {
 		if (!filterObject.bool[newFilter.occurrenceType]) {
 			filterObject.bool[newFilter.occurrenceType] = [];
@@ -604,7 +577,7 @@ export class QueryBuilder {
 		const aggs: any = {};
 		forEach(searchRequest.requestedAggs || AGGS_PROPERTIES, (aggProperty) => {
 			const elasticProperty =
-				READABLE_TO_ELASTIC_FILTER_NAMES[aggProperty as SearchFilterField];
+				READABLE_TO_ELASTIC_FILTER_NAMES[aggProperty as IeObjectsSearchFilterField];
 			if (!elasticProperty) {
 				throw new InternalServerErrorException(
 					`Failed to resolve agg property: ${aggProperty}`
@@ -633,7 +606,7 @@ export class QueryBuilder {
 	 * },
 	 * @param prop
 	 */
-	private static filterSuffix(prop: SearchFilterField): string {
+	private static filterSuffix(prop: IeObjectsSearchFilterField): string {
 		return NEEDS_FILTER_SUFFIX[prop] ? `.${NEEDS_FILTER_SUFFIX[prop]}` : '';
 	}
 
@@ -648,7 +621,7 @@ export class QueryBuilder {
 	 * },
 	 * @param prop
 	 */
-	private static aggSuffix(prop: SearchFilterField): string {
+	private static aggSuffix(prop: IeObjectsSearchFilterField): string {
 		return NEEDS_AGG_SUFFIX[prop] ? `.${NEEDS_AGG_SUFFIX[prop]}` : '';
 	}
 

--- a/src/modules/ie-objects/helpers/check-and-fix-format-filter.spec.ts
+++ b/src/modules/ie-objects/helpers/check-and-fix-format-filter.spec.ts
@@ -1,4 +1,4 @@
-import { Operator, SearchFilterField } from '../elasticsearch/elasticsearch.consts';
+import { IeObjectsSearchFilterField, Operator } from '../elasticsearch/elasticsearch.consts';
 import { MediaFormat } from '../ie-objects.types';
 
 import { checkAndFixFormatFilter } from './check-and-fix-format-filter';
@@ -8,7 +8,7 @@ describe('checkAndFixFormatFilter', () => {
 		const fixedQuery = checkAndFixFormatFilter({
 			filters: [
 				{
-					field: SearchFilterField.FORMAT,
+					field: IeObjectsSearchFilterField.FORMAT,
 					value: MediaFormat.VIDEO,
 					operator: Operator.IS,
 				},
@@ -21,7 +21,7 @@ describe('checkAndFixFormatFilter', () => {
 		const fixedQuery = checkAndFixFormatFilter({
 			filters: [
 				{
-					field: SearchFilterField.FORMAT,
+					field: IeObjectsSearchFilterField.FORMAT,
 					multiValue: [MediaFormat.VIDEO],
 					operator: Operator.IS,
 				},

--- a/src/modules/ie-objects/helpers/convert-node-to-es-query-filter-objects.spec.ts
+++ b/src/modules/ie-objects/helpers/convert-node-to-es-query-filter-objects.spec.ts
@@ -8,7 +8,7 @@ import {
 	mockConvertNodeToEsQueryFilterObject4,
 } from '../mocks/elasticsearch.mock';
 
-import { Operator, SearchFilterField } from './../elasticsearch/elasticsearch.consts';
+import { IeObjectsSearchFilterField, Operator } from './../elasticsearch/elasticsearch.consts';
 import { convertNodeToEsQueryFilterObjects } from './convert-node-to-es-query-filter-objects';
 
 (jsep as any).removeAllBinaryOps();
@@ -27,7 +27,7 @@ describe('Convert node to es query filter objects', () => {
 			jsep(node),
 			esQuerySearchTemplate,
 			{
-				field: SearchFilterField.QUERY,
+				field: IeObjectsSearchFilterField.QUERY,
 				value: node,
 				operator: Operator.CONTAINS,
 			}
@@ -44,7 +44,7 @@ describe('Convert node to es query filter objects', () => {
 			jsep(node),
 			esQuerySearchTemplate,
 			{
-				field: SearchFilterField.QUERY,
+				field: IeObjectsSearchFilterField.QUERY,
 				value: node,
 				operator: Operator.CONTAINS,
 			}
@@ -60,7 +60,7 @@ describe('Convert node to es query filter objects', () => {
 			jsep(node),
 			esQuerySearchTemplate,
 			{
-				field: SearchFilterField.QUERY,
+				field: IeObjectsSearchFilterField.QUERY,
 				value: node,
 				operator: Operator.CONTAINS,
 			}
@@ -77,7 +77,7 @@ describe('Convert node to es query filter objects', () => {
 			jsep(node),
 			esQuerySearchTemplate,
 			{
-				field: SearchFilterField.QUERY,
+				field: IeObjectsSearchFilterField.QUERY,
 				value: node,
 				operator: Operator.CONTAINS,
 			}

--- a/src/modules/ie-objects/services/ie-objects.service.spec.ts
+++ b/src/modules/ie-objects/services/ie-objects.service.spec.ts
@@ -6,7 +6,7 @@ import nock from 'nock';
 
 import { Configuration } from '~config';
 
-import { Operator, SearchFilterField } from '../elasticsearch/elasticsearch.consts';
+import { IeObjectsSearchFilterField, Operator } from '../elasticsearch/elasticsearch.consts';
 import { ElasticsearchResponse } from '../ie-objects.types';
 import {
 	mockGqlIeObjectFindByCollectionId,
@@ -403,7 +403,7 @@ describe('ieObjectsService', () => {
 		it('should return the value of the filter when the field is query', () => {
 			const result = ieObjectsService.getSimpleSearchTermsFromBooleanExpression([
 				{
-					field: SearchFilterField.QUERY,
+					field: IeObjectsSearchFilterField.QUERY,
 					operator: Operator.CONTAINS,
 					value: 'example',
 				},
@@ -414,12 +414,12 @@ describe('ieObjectsService', () => {
 		it('should only return the value of the filter where the field is "query"', () => {
 			const result = ieObjectsService.getSimpleSearchTermsFromBooleanExpression([
 				{
-					field: SearchFilterField.QUERY,
+					field: IeObjectsSearchFilterField.QUERY,
 					operator: Operator.CONTAINS,
 					value: 'example',
 				},
 				{
-					field: SearchFilterField.NAME,
+					field: IeObjectsSearchFilterField.NAME,
 					operator: Operator.CONTAINS,
 					value: 'example2',
 				},
@@ -429,7 +429,7 @@ describe('ieObjectsService', () => {
 		it('should return an empty array when there are no filter objects containing "field" with value "query"', () => {
 			const result = ieObjectsService.getSimpleSearchTermsFromBooleanExpression([
 				{
-					field: SearchFilterField.NAME,
+					field: IeObjectsSearchFilterField.NAME,
 					operator: Operator.CONTAINS,
 					value: 'example',
 				},

--- a/src/modules/ie-objects/services/ie-objects.service.ts
+++ b/src/modules/ie-objects/services/ie-objects.service.ts
@@ -47,7 +47,7 @@ import {
 	GetRelatedObjectsQueryVariables,
 	Lookup_Maintainer_Visitor_Space_Status_Enum as VisitorSpaceStatus,
 } from '~generated/graphql-db-types-hetarchief';
-import { SearchFilterField } from '~modules/ie-objects/elasticsearch/elasticsearch.consts';
+import { IeObjectsSearchFilterField } from '~modules/ie-objects/elasticsearch/elasticsearch.consts';
 import { convertStringToSearchTerms } from '~modules/ie-objects/helpers/convert-string-to-search-terms';
 import { SpacesService } from '~modules/spaces/services/spaces.service';
 import { SessionUserEntity } from '~modules/users/classes/session-user';
@@ -618,7 +618,7 @@ export class IeObjectsService {
 		filters: IeObjectsQueryDto['filters']
 	): string[] {
 		const searchTerm = filters.find(
-			(searchFilter) => searchFilter.field === SearchFilterField.QUERY
+			(searchFilter) => searchFilter.field === IeObjectsSearchFilterField.QUERY
 		)?.value;
 		if (!searchTerm) {
 			return [];


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1604

Requires client pr: https://github.com/viaacode/hetarchief-client/pull/783

🔴🔴🔴  Needs to be merged at the same time as the client or search will break

* Fixes some issues with the search:
    * Fixed issue with fuzzy search
    * Fixed issue with consultableRemote
* Renamed consultableRemote to ConsultableOnlyOnLocation to get rid of the inverted filter, since it was causing the filter handing in the backend to be more difficult
* Added tests in the backend for checking fuzzy search, exact search, consultableOnlyOnLocation and consultableMedia
* Allow no filter to be passed for consultableOnlyOnLocation => means no filter was enabled

![image](https://user-images.githubusercontent.com/1710840/230646157-ce302b2c-a129-4fc2-91c8-84b6dfa1422a.png)



before:
![image](https://user-images.githubusercontent.com/1710840/230645244-cc97fcb8-ffe0-4c4a-b01b-1d5448e96e83.png)



after:
![image](https://user-images.githubusercontent.com/1710840/230641961-04a3e4ab-25e9-4aea-a738-7176e037797b.png)
