### PR TITLE
fix(arc-1541): switch CM to bulk endpoint, fix newsletter check

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -28,7 +28,10 @@ import { TranslationsModule } from '~modules/translations';
 import { UsersModule } from '~modules/users';
 import { VisitsModule } from '~modules/visits';
 import { PermissionGuard } from '~shared/guards/permission.guard';
+import { checkRequiredEnvs } from '~shared/helpers/env-check';
 import { SessionService } from '~shared/services/session.service';
+
+checkRequiredEnvs(['ADMIN_CORE_ROUTES_PREFIX']);
 
 @Module({
 	imports: [

--- a/src/modules/campaign-monitor/dto/campaign-monitor.dto.ts
+++ b/src/modules/campaign-monitor/dto/campaign-monitor.dto.ts
@@ -77,6 +77,7 @@ export class CampaignMonitorVisitData {
 	@ApiPropertyOptional({ type: String })
 	end_time?: string;
 }
+
 export class CampaignMonitorMaterialRequestData {
 	@IsString()
 	@IsOptional()
@@ -134,7 +135,7 @@ export class CampaignMonitorUpdatePreferencesData {
 
 	@IsString()
 	@IsOptional()
-	CustomFields: { Key: string; Value: any; Clear: boolean }[];
+	CustomFields: { Key: string; Value: any }[];
 }
 
 export class RequestListItem {

--- a/src/modules/campaign-monitor/mocks/campaign-monitor.mocks.ts
+++ b/src/modules/campaign-monitor/mocks/campaign-monitor.mocks.ts
@@ -128,42 +128,34 @@ export const mockNewsletterTemplateDataWithNewsletter = {
 		{
 			Key: 'usergroup',
 			Value: mockUserInfo.usergroup,
-			Clear: false,
 		},
 		{
 			Key: 'is_key_user',
 			Value: mockUserInfo.is_key_user,
-			Clear: false,
 		},
 		{
 			Key: 'firstname',
 			Value: mockUserInfo.firstName,
-			Clear: false,
 		},
 		{
 			Key: 'lastname',
 			Value: mockUserInfo.lastName,
-			Clear: false,
 		},
 		{
 			Key: 'created_date',
 			Value: null,
-			Clear: true,
 		},
 		{
 			Key: 'last_access_date',
 			Value: null,
-			Clear: true,
 		},
 		{
 			Key: 'organisation',
 			Value: null,
-			Clear: true,
 		},
 		{
 			Key: 'optin_mail_lists',
 			Value: 'newsletter',
-			Clear: false,
 		},
 	],
 };

--- a/src/modules/campaign-monitor/services/campaign-monitor.service.spec.ts
+++ b/src/modules/campaign-monitor/services/campaign-monitor.service.spec.ts
@@ -445,7 +445,12 @@ describe('CampaignMonitorService', () => {
 					)}.json/?${queryString.stringify({ email: mockUser.email })}`
 				)
 				.reply(201, {
-					State: 'Active',
+					CustomFields: [
+						{
+							Key: 'optin_mail_lists',
+							Value: 'newsletter',
+						},
+					],
 				});
 			const result = await campaignMonitorService.fetchNewsletterPreferences(mockUser.email);
 			expect(result).toEqual({ newsletter: true });
@@ -462,7 +467,9 @@ describe('CampaignMonitorService', () => {
 						'CAMPAIGN_MONITOR_OPTIN_LIST_HETARCHIEF'
 					)}.json/?${queryString.stringify({ email: mockUser.email })}`
 				)
-				.reply(203, {});
+				.reply(203, {
+					CustomFields: [],
+				});
 			const result = await campaignMonitorService.fetchNewsletterPreferences(mockUser.email);
 			expect(result).toEqual({ newsletter: false });
 		});
@@ -510,7 +517,9 @@ describe('CampaignMonitorService', () => {
 						'CAMPAIGN_MONITOR_SUBSCRIBER_API_VERSION'
 					)}/${mockConfigService.get(
 						'CAMPAIGN_MONITOR_SUBSCRIBER_API_ENDPOINT'
-					)}/${mockConfigService.get('CAMPAIGN_MONITOR_OPTIN_LIST_HETARCHIEF')}.json`
+					)}/${mockConfigService.get(
+						'CAMPAIGN_MONITOR_OPTIN_LIST_HETARCHIEF'
+					)}/import.json`
 				)
 				.replyWithError('');
 
@@ -535,7 +544,9 @@ describe('CampaignMonitorService', () => {
 						'CAMPAIGN_MONITOR_SUBSCRIBER_API_VERSION'
 					)}/${mockConfigService.get(
 						'CAMPAIGN_MONITOR_SUBSCRIBER_API_ENDPOINT'
-					)}/${mockConfigService.get('CAMPAIGN_MONITOR_OPTIN_LIST_HETARCHIEF')}.json`
+					)}/${mockConfigService.get(
+						'CAMPAIGN_MONITOR_OPTIN_LIST_HETARCHIEF'
+					)}/import.json`
 				)
 				.reply(201, {});
 
@@ -555,7 +566,9 @@ describe('CampaignMonitorService', () => {
 						'CAMPAIGN_MONITOR_SUBSCRIBER_API_VERSION'
 					)}/${mockConfigService.get(
 						'CAMPAIGN_MONITOR_SUBSCRIBER_API_ENDPOINT'
-					)}/${mockConfigService.get('CAMPAIGN_MONITOR_OPTIN_LIST_HETARCHIEF')}.json`
+					)}/${mockConfigService.get(
+						'CAMPAIGN_MONITOR_OPTIN_LIST_HETARCHIEF'
+					)}/import.json`
 				)
 				.reply(201, {});
 
@@ -575,7 +588,9 @@ describe('CampaignMonitorService', () => {
 						'CAMPAIGN_MONITOR_SUBSCRIBER_API_VERSION'
 					)}/${mockConfigService.get(
 						'CAMPAIGN_MONITOR_SUBSCRIBER_API_ENDPOINT'
-					)}/${mockConfigService.get('CAMPAIGN_MONITOR_OPTIN_LIST_HETARCHIEF')}.json`
+					)}/${mockConfigService.get(
+						'CAMPAIGN_MONITOR_OPTIN_LIST_HETARCHIEF'
+					)}/import.json`
 				)
 				.reply(201, {});
 
@@ -667,7 +682,9 @@ describe('CampaignMonitorService', () => {
 						'CAMPAIGN_MONITOR_SUBSCRIBER_API_VERSION'
 					)}/${mockConfigService.get(
 						'CAMPAIGN_MONITOR_SUBSCRIBER_API_ENDPOINT'
-					)}/${mockConfigService.get('CAMPAIGN_MONITOR_OPTIN_LIST_HETARCHIEF')}.json`
+					)}/${mockConfigService.get(
+						'CAMPAIGN_MONITOR_OPTIN_LIST_HETARCHIEF'
+					)}/import.json`
 				)
 				.reply(201, {});
 


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1541

* Use bulk import endpoint to avoid 429 rate limit errors
* Fix checking for subscribed to newsletter through custom field
* Don't clear values, but set them to be empty

The switch between on and off happens after 15 seconds in campaign monitor. So reloading the page after 15 seconds should reflect the change you made.

![image](https://user-images.githubusercontent.com/1710840/232534861-bd65aaec-1ee0-4ba1-ae1c-bdf3afe399ee.png)
![image](https://user-images.githubusercontent.com/1710840/232534869-ce07cff3-00de-4c99-81b7-2349c079b3a7.png)
