### PR TITLE
fix(arc-1612): allow meemoo admin to get inactive visitor space info

### DIFF
--- a/src/modules/spaces/controllers/spaces.controller.spec.ts
+++ b/src/modules/spaces/controllers/spaces.controller.spec.ts
@@ -155,7 +155,10 @@ describe('SpacesController', () => {
 	describe('getSpaceBySlug', () => {
 		it('should return a space by slug', async () => {
 			mockSpacesService.findBySlug.mockResolvedValueOnce(mockSpacesResponse.items[0]);
-			const space = await spacesController.getSpaceBySlug('huis-van-alijn');
+			const space = await spacesController.getSpaceBySlug(
+				'huis-van-alijn',
+				new SessionUserEntity(mockUser)
+			);
 			expect(space.id).toEqual('1');
 		});
 
@@ -164,7 +167,10 @@ describe('SpacesController', () => {
 
 			let error;
 			try {
-				await spacesController.getSpaceBySlug('huis-van-alijn');
+				await spacesController.getSpaceBySlug(
+					'huis-van-alijn',
+					new SessionUserEntity(mockUser)
+				);
 			} catch (err) {
 				error = err;
 			}
@@ -179,7 +185,10 @@ describe('SpacesController', () => {
 			mockSpacesService.findBySlug.mockResolvedValueOnce(mockSpacesResponse.items[2]);
 
 			try {
-				await spacesController.getSpaceBySlug('huis-van-alijn');
+				await spacesController.getSpaceBySlug(
+					'huis-van-alijn',
+					new SessionUserEntity(mockUser)
+				);
 				fail('getSpaceBySlug should throw an error when the space is inactive');
 			} catch (err) {
 				expect(err?.response).toEqual({


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1612

example url: http://localhost:3200/admin/bezoekersruimtesbeheer/bezoekersruimtes/bruzzel

before:
![image](https://user-images.githubusercontent.com/1710840/235191463-16876cd2-7dc8-432c-8f1f-5e02a6170945.png)


after:
![image](https://user-images.githubusercontent.com/1710840/235191421-42ac328f-7d6d-40e6-954a-0e538c299498.png)
![image](https://user-images.githubusercontent.com/1710840/235191428-60e4a372-d9cf-493c-819c-80fe95b024c0.png)
