### PR TITLE
fix(arc-1659): throw notFound error when meemoo admin finds no space

### DIFF
--- a/src/modules/visits/controllers/visits.controller.ts
+++ b/src/modules/visits/controllers/visits.controller.ts
@@ -240,6 +240,16 @@ export class VisitsController {
 			user.getGroupName() === GroupName.MEEMOO_ADMIN
 		) {
 			const spaceInfo = await this.spacesService.findBySlug(visitorSpaceSlug);
+
+			if (!spaceInfo) {
+				throw new NotFoundException(
+					this.translationsService.t(
+						'modules/visits/controllers/visits___space-with-slug-name-was-not-found',
+						{ name: visitorSpaceSlug }
+					)
+				);
+			}
+
 			// Return fake visit request that is approved and valid forever
 			return {
 				spaceId: spaceInfo.id,


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1659

The objects in the ticket are only on QAS, not on TST, so we can't really test this. 
There will also a FE PR for this ticket: https://github.com/viaacode/hetarchief-client/pull/877