### PR TITLE
fix(1655): add license filter to filter on objects with bzt license

### DIFF
--- a/src/modules/ie-objects/elasticsearch/elasticsearch.consts.ts
+++ b/src/modules/ie-objects/elasticsearch/elasticsearch.consts.ts
@@ -45,6 +45,7 @@ export enum IeObjectsSearchFilterField {
 	CAST = 'cast',
 	IDENTIFIER = 'identifier',
 	OBJECT_TYPE = 'objectType',
+	LICENSES = 'license', // Used to filter objects that are in a visitor space
 	CAPTION = 'caption', // Not available in database: https://docs.google.com/spreadsheets/d/1xAtHfkpDi4keSsBol7pw0cQAvCmg2hWRz8oxM6cP7zo/edit#gid=0
 	TRANSCRIPT = 'transcript', // Not available in database: https://docs.google.com/spreadsheets/d/1xAtHfkpDi4keSsBol7pw0cQAvCmg2hWRz8oxM6cP7zo/edit#gid=0
 	CATEGORIE = 'categorie', // Not available in database: https://docs.google.com/spreadsheets/d/1xAtHfkpDi4keSsBol7pw0cQAvCmg2hWRz8oxM6cP7zo/edit#gid=0
@@ -121,6 +122,7 @@ export const DEFAULT_QUERY_TYPE: { [prop in IeObjectsSearchFilterField]: QueryTy
 	[IeObjectsSearchFilterField.DURATION]: QueryType.RANGE,
 	[IeObjectsSearchFilterField.LANGUAGE]: QueryType.TERMS,
 	[IeObjectsSearchFilterField.MEDIUM]: QueryType.TERMS,
+	[IeObjectsSearchFilterField.LICENSES]: QueryType.TERMS,
 
 	// Should never be used since these are marked as multi match fields
 	// But we include it to get stricter type checks on missing fields
@@ -172,6 +174,7 @@ export const READABLE_TO_ELASTIC_FILTER_NAMES: {
 	[IeObjectsSearchFilterField.MEDIUM]: 'dcterms_medium',
 	[IeObjectsSearchFilterField.OBJECT_TYPE]: 'ebucore_object_type',
 	[IeObjectsSearchFilterField.IDENTIFIER]: 'schema_identifier',
+	[IeObjectsSearchFilterField.LICENSES]: 'schema_license',
 };
 
 export const NUMBER_OF_FILTER_OPTIONS_DEFAULT = 40;


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1655

Add a filter option to only receive search result objects that have specific licenses
So we can show only objects with the BEZOEKRERTOOL license on the search page if a user selected a visitor space

```json
{
  "size": 39,
  "from": 0,
  "query": {
    "bool": {
      "should": [
        {
          "bool": {
            "filter": [],
            "must": [
              {
                "term": {
                  "schema_maintainer.schema_identifier": "OR-7h1dk9t"
                }
              },
              {
                "terms": {
                  "schema_license": [
                    "BEZOEKERTOOL-METADATA-ALL",
                    "BEZOEKERTOOL-CONTENT"
                  ]
                }
              }
            ]
          }
        },
```

before:
![image](https://user-images.githubusercontent.com/1710840/236881042-72aebd32-93eb-497f-a9ca-144a95c2f2e4.png)

after:
![image](https://user-images.githubusercontent.com/1710840/236881061-b234b7cf-0050-441f-b56d-212daa228c1f.png)
