### PR TITLE
fix(arc-1536): prefer-or-ids over school ids from ldap info

### DIFF
--- a/src/modules/auth/controllers/het-archief.controller.ts
+++ b/src/modules/auth/controllers/het-archief.controller.ts
@@ -129,9 +129,13 @@ export class HetArchiefController {
 			SessionHelper.setIdpUserInfo(session, Idp.HETARCHIEF, ldapUser);
 
 			const apps = ldapUser?.attributes?.apps ?? [];
+
+			// Prefer an organisation with an OR-id instead of a school
+			// TODO wait for schools to be available in the organisation api cache and identify the business vs the schools
 			const organisationId = isEmpty(ldapUser?.attributes?.o)
 				? null
-				: ldapUser.attributes.o[0];
+				: ldapUser.attributes.o.find((org) => org.toLowerCase().startsWith('or')) ||
+				  ldapUser.attributes.o[0];
 
 			let organisation: Organisation | null = null;
 			if (organisationId) {


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1536

prefer the OR-ids over the school ids, when filling in the organisation of a user from their ldap o (organisation) attribute

In the future we'll want to apply the same fix as for avo where we can identify schools vs organisations based on the organisation api cache