### PR TITLE
fix(arc-1696): add insta cp metadata limited to matrix

### DIFF
--- a/src/modules/ie-objects/ie-objects.conts.ts
+++ b/src/modules/ie-objects/ie-objects.conts.ts
@@ -121,6 +121,7 @@ export const IE_OBJECT_METADATA_SET_BY_OBJECT_AND_USER_SECTOR: Record<
 		[IeObjectSector.PUBLIC]: [
 			IeObjectLicense.PUBLIEK_METADATA_ALL,
 			IeObjectLicense.INTRA_CP_METADATA_ALL,
+			IeObjectLicense.INTRA_CP_METADATA_LTD,
 			IeObjectLicense.BEZOEKERTOOL_METADATA_ALL,
 		],
 		[IeObjectSector.RURAL]: [IeObjectLicense.INTRA_CP_METADATA_LTD],


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1696

Thought process: If a user is allowed to see all the Intra cp metadata, he should also be allowed to see the limited intra cp metadata. Because the limited metadata is included in all the metadata.

Before: logged in as user.OR-sf2mb2h@meemoo.be: 
![image](https://github.com/viaacode/hetarchief-proxy/assets/125865682/9fc4d1af-3159-4d62-8ce9-f8d28b7aa9d7)

After: logged in as user.OR-sf2mb2h@meemoo.be: 
![image](https://github.com/viaacode/hetarchief-proxy/assets/125865682/d9304894-52ef-45e6-bd67-d8edbecdfa3b)

![image](https://github.com/viaacode/hetarchief-proxy/assets/125865682/c7198e0e-2210-4f15-9b31-968faa281894)
