### PR TITLE
fix(arc-1708): get sector from object itself

### DIFF
--- a/src/modules/ie-objects/services/ie-objects.service.ts
+++ b/src/modules/ie-objects/services/ie-objects.service.ts
@@ -380,7 +380,9 @@ export class IeObjectsService {
 			maintainerDescription: gqlIeObject?.maintainer?.information?.description,
 			maintainerSiteUrl: gqlIeObject?.maintainer?.information?.homepage_url,
 			maintainerFormUrl: gqlIeObject?.maintainer?.information?.form_url,
-			sector: gqlIeObject?.haorg_organization_type as IeObjectSector,
+			sector:
+				(gqlIeObject?.haorg_organization_type as IeObjectSector) ??
+				(gqlIeObject?.maintainer?.information?.haorg_organization_type as IeObjectSector),
 			name: gqlIeObject?.schema_name,
 			publisher: gqlIeObject?.schema_publisher,
 			spatial: gqlIeObject?.schema_spatial_coverage,

--- a/src/modules/ie-objects/services/ie-objects.service.ts
+++ b/src/modules/ie-objects/services/ie-objects.service.ts
@@ -380,7 +380,7 @@ export class IeObjectsService {
 			maintainerDescription: gqlIeObject?.maintainer?.information?.description,
 			maintainerSiteUrl: gqlIeObject?.maintainer?.information?.homepage_url,
 			maintainerFormUrl: gqlIeObject?.maintainer?.information?.form_url,
-			sector: gqlIeObject?.maintainer?.information?.haorg_organization_type as IeObjectSector,
+			sector: gqlIeObject?.haorg_organization_type as IeObjectSector,
 			name: gqlIeObject?.schema_name,
 			publisher: gqlIeObject?.schema_publisher,
 			spatial: gqlIeObject?.schema_spatial_coverage,


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1708

Those objects accessthrough now have the sector, the screen is now displaying a different error message but that is supposed to be fixed in ARC-1740.

![image](https://github.com/viaacode/hetarchief-proxy/assets/125865682/409b2c3c-e274-4d8a-bdc4-166497290cb7)
