### PR TITLE
fix(arc-1768): show visitor space objects only to cp admin and kiosk

### DIFF
--- a/src/modules/ie-objects/elasticsearch/queryBuilder.ts
+++ b/src/modules/ie-objects/elasticsearch/queryBuilder.ts
@@ -469,7 +469,10 @@ export class QueryBuilder {
 		];
 
 		// KIOSK users and CP Admins always have access to the visitor space that they are linked to.
-		if (user.getMaintainerId()) {
+		if (
+			[GroupName.CP_ADMIN, GroupName.KIOSK_VISITOR].includes(user.getGroupName()) &&
+			user.getMaintainerId()
+		) {
 			checkSchemaLicenses = [
 				...checkSchemaLicenses,
 				{


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1768

And not to basic users that have key rights and are linked to an organization

test account: hetarchief2.0+autsleutelvrt@meemoo.be
test page: http://localhost:3200/zoeken?aanbieder=&format=all&orderDirection=desc&orderProp=relevance&page=2

before:
![image](https://github.com/viaacode/hetarchief-proxy/assets/1710840/94475ea5-d2fd-4ce8-b335-d08c97d91897)

after:
![image](https://github.com/viaacode/hetarchief-proxy/assets/1710840/e877a329-2954-4e0a-b355-d93242656e76)
