### PR TITLE
fix(arc-1799): trigger events when material requests are sent out

### DIFF
--- a/src/modules/material-requests/controllers/material-requests.controller.spec.ts
+++ b/src/modules/material-requests/controllers/material-requests.controller.spec.ts
@@ -12,6 +12,7 @@ import { MaterialRequestsService } from '../services/material-requests.service';
 
 import { MaterialRequestsController } from './material-requests.controller';
 
+import { EventsService } from '~modules/events/services/events.service';
 import { SessionUserEntity } from '~modules/users/classes/session-user';
 import { Permission } from '~modules/users/types';
 import { TestingLogger } from '~shared/logging/test-logger';
@@ -27,6 +28,10 @@ const mockMaterialRequestsService: Partial<
 	deleteMaterialRequest: jest.fn(),
 };
 
+const mockEventsService: Partial<Record<keyof EventsService, jest.SpyInstance>> = {
+	insertEvents: jest.fn(),
+};
+
 describe('MaterialRequestsController', () => {
 	let materialRequestsController: MaterialRequestsController;
 
@@ -38,6 +43,10 @@ describe('MaterialRequestsController', () => {
 				{
 					provide: MaterialRequestsService,
 					useValue: mockMaterialRequestsService,
+				},
+				{
+					provide: EventsService,
+					useValue: mockEventsService,
 				},
 			],
 		})

--- a/src/modules/material-requests/material-requests.module.ts
+++ b/src/modules/material-requests/material-requests.module.ts
@@ -5,12 +5,13 @@ import { MaterialRequestsController } from './controllers/material-requests.cont
 import { MaterialRequestsService } from './services/material-requests.service';
 
 import { CampaignMonitorModule } from '~modules/campaign-monitor';
+import { EventsModule } from '~modules/events';
 import { OrganisationsModule } from '~modules/organisations/organisations.module';
 
 @Module({
 	controllers: [MaterialRequestsController],
 	providers: [MaterialRequestsService],
-	imports: [DataModule, CampaignMonitorModule, OrganisationsModule],
+	imports: [DataModule, CampaignMonitorModule, OrganisationsModule, EventsModule],
 	exports: [MaterialRequestsService],
 })
 export class MaterialRequestsModule {}


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1799

We were triggering events for material requests from the client that go through the external form url for VRT and UGent, but we had forgotten to trigger the events for the regular material requests when they are sent through the backend.

![image](https://github.com/viaacode/hetarchief-proxy/assets/1710840/c1189d0e-62b5-4475-8a7c-0364fe6847b7)
