### PR TITLE
fix(ARC-2029): store idp uuid in correct column for new users

### DIFF
--- a/src/modules/users/services/users.service.ts
+++ b/src/modules/users/services/users.service.ts
@@ -115,9 +115,8 @@ export class UsersService {
 		this.logger.debug(`user ${createdUser.id} created`);
 
 		// Link the user with the identity
-		const newUserIdentity = {
-			id: idpId,
-			identity_id: idp,
+		const newUserIdentity: InsertUserIdentityMutationVariables['newUserIdentity'] = {
+			identity_id: idpId,
 			identity_provider_name: idp,
 			profile_id: createdUser.id,
 		};


### PR DESCRIPTION
![image](https://github.com/viaacode/hetarchief-proxy/assets/1710840/1f878904-64a3-41ae-becc-2326ddb38ea4)
