### PR TITLE
fix(ARC-2028): correctly link new users to their organisation

### DIFF
--- a/src/modules/users/services/users.service.ts
+++ b/src/modules/users/services/users.service.ts
@@ -101,12 +101,13 @@ export class UsersService {
 		idpId: string
 	): Promise<User> {
 		// TODO duplicate user handling
-		const newUser = {
+		const newUser: InsertUserMutationVariables['newUser'] = {
 			first_name: createUserDto.firstName,
 			last_name: createUserDto.lastName,
 			mail: createUserDto.email,
 			group_id: createUserDto.groupId,
 			is_key_user: createUserDto.isKeyUser,
+			organisation_schema_identifier: createUserDto.organisationId,
 		};
 		const { insert_users_profile_one: createdUser } = await this.dataService.execute<
 			InsertUserMutation,


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-2028

logging in with a new kiosk user now shows the correct content and visitor space:
![image](https://github.com/viaacode/hetarchief-proxy/assets/1710840/300dbea4-46b8-4388-8faa-c5a2bea05f96)
