### PR TITLE
fix(ARC-2521): do not read all/limited prop for name advanced filters

### DIFF
--- a/src/modules/ie-objects/elasticsearch/queryBuilder.ts
+++ b/src/modules/ie-objects/elasticsearch/queryBuilder.ts
@@ -419,8 +419,7 @@ export class QueryBuilder {
 							MULTI_MATCH_QUERY_MAPPING.fuzzy.advancedQuery[metadataAccessType];
 						textFilters = [buildFreeTextFilter(searchTemplate, searchFilter)];
 					} else {
-						const searchTemplate =
-							MULTI_MATCH_QUERY_MAPPING.fuzzy[searchFilter.field][metadataAccessType];
+						const searchTemplate = MULTI_MATCH_QUERY_MAPPING.fuzzy[searchFilter.field];
 						textFilters = [buildFreeTextFilter(searchTemplate, searchFilter)];
 					}
 


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-2521

also improve error logging for ie objects endpoint

before:
![image](https://github.com/user-attachments/assets/4dc47519-57ba-4992-9124-97105cf25575)


after:
![image](https://github.com/user-attachments/assets/d53f66af-84f1-4b1b-a167-8cd35d2b1552)


