### PR TITLE
fix(ARC-2511): use maintainer contact email directly

### DIFF
--- a/src/modules/material-requests/controllers/material-requests.controller.ts
+++ b/src/modules/material-requests/controllers/material-requests.controller.ts
@@ -246,7 +246,7 @@ export class MaterialRequestsController {
 				message: 'Material request list could not be send.',
 				innerException: err,
 			});
-			console.log(error);
+			console.error(error);
 
 			throw error;
 		}

--- a/src/modules/material-requests/controllers/material-requests.controller.ts
+++ b/src/modules/material-requests/controllers/material-requests.controller.ts
@@ -30,7 +30,6 @@ import { MaterialRequestsService } from '../services/material-requests.service';
 
 import { EventsService } from '~modules/events/services/events.service';
 import { type LogEvent, LogEventType } from '~modules/events/types';
-import { OrganisationContactPointType } from '~modules/organisations/organisations.types';
 import { SessionUserEntity } from '~modules/users/classes/session-user';
 import { GroupId, GroupName, Permission } from '~modules/users/types';
 import { Idp } from '~shared/auth/auth.types';
@@ -179,9 +178,6 @@ export class MaterialRequestsController {
 
 			materialRequests.items.forEach((materialRequest: MaterialRequest) => {
 				// If the email does not exist, the campaign monitor service will default to process.env.MEEMOO_MAINTAINER_MISSING_EMAIL_FALLBACK
-				materialRequest.contactMail = materialRequest?.contactMail?.find(
-					(contact) => contact.contact_type === OrganisationContactPointType.ontsluiting
-				)?.email;
 				materialRequest.requesterCapacity = sendRequestListDto.type;
 				materialRequest.organisation = sendRequestListDto?.organisation;
 			});
@@ -245,11 +241,14 @@ export class MaterialRequestsController {
 			);
 
 			return { message: 'success' };
-		} catch (error) {
-			throw new InternalServerErrorException({
+		} catch (err) {
+			const error = new InternalServerErrorException({
 				message: 'Material request list could not be send.',
-				error,
+				innerException: err,
 			});
+			console.log(error);
+
+			throw error;
 		}
 	}
 

--- a/src/modules/material-requests/material-requests.types.ts
+++ b/src/modules/material-requests/material-requests.types.ts
@@ -33,7 +33,7 @@ export interface MaterialRequest {
 	requesterUserGroupLabel?: string;
 	requesterUserGroupDescription?: string;
 	maintainerLogo?: string;
-	contactMail?: any;
+	contactMail?: string;
 	organisation?: string | null;
 }
 


### PR DESCRIPTION
https://github.com/viaacode/hetarchief-client/pull/1259

since this is already mapped in the adapt function, we no longer need to map it during material request sending

client PR: https://github.com/viaacode/hetarchief-client/pull/1259

![image](https://github.com/user-attachments/assets/4431e379-ba8b-43be-b360-bc3301cc612b)
![image](https://github.com/user-attachments/assets/8db7fa0a-bdd9-4693-aedc-9c19e1907057)

