### PR TITLE
fix(ARC-2583): count videofragments as video in elasticsearch aggregates

### DIFF
--- a/src/modules/folders/controllers/folders.controller.spec.ts
+++ b/src/modules/folders/controllers/folders.controller.spec.ts
@@ -58,7 +58,7 @@ const mockFolderObjectsResponse: IPagination<Partial<IeObject & { folderEntryCre
 				name: 'CGSO. De mannenbeweging - mannenemancipatie - 1982',
 				datePublished: '2015-09-19T12:08:24',
 				creator: null,
-				dctermsFormat: IeObjectType.Video,
+				dctermsFormat: IeObjectType.VIDEO,
 				numberOfPages: null,
 				thumbnailUrl:
 					'/viaa/AMSAB/5dc89b7e75e649e191cd86196c255147cd1a0796146d4255acfde239296fa534/keyframes-thumb/keyframes_1_1/keyframe1.jpg',

--- a/src/modules/folders/services/folders.service.spec.ts
+++ b/src/modules/folders/services/folders.service.spec.ts
@@ -142,7 +142,7 @@ const mockFolderObject: Partial<IeObject> & { folderEntryCreatedAt: string } = {
 	name: 'CGSO. De mannenbeweging - mannenemancipatie - 1982',
 	dctermsAvailable: '2015-09-19T12:08:24',
 	creator: null,
-	dctermsFormat: IeObjectType.Video,
+	dctermsFormat: IeObjectType.VIDEO,
 	numberOfPages: null,
 	thumbnailUrl:
 		'/viaa/AMSAB/5dc89b7e75e649e191cd86196c255147cd1a0796146d4255acfde239296fa534/keyframes-thumb/keyframes_1_1/keyframe1.jpg',

--- a/src/modules/ie-objects/elasticsearch/queryBuilder.spec.ts
+++ b/src/modules/ie-objects/elasticsearch/queryBuilder.spec.ts
@@ -1,4 +1,4 @@
-import { IeObjectSector, MediaFormat } from '../ie-objects.types';
+import { IeObjectSector, IeObjectType } from '../ie-objects.types';
 
 import {
 	ElasticsearchField,
@@ -219,7 +219,7 @@ describe('QueryBuilder', () => {
 					filters: [
 						{
 							field: IeObjectsSearchFilterField.FORMAT,
-							value: MediaFormat.VIDEO,
+							value: IeObjectType.VIDEO,
 							operator: Operator.IS,
 						},
 					],
@@ -516,7 +516,7 @@ describe('QueryBuilder', () => {
 					filters: [
 						{
 							field: IeObjectsSearchFilterField.FORMAT,
-							value: MediaFormat.VIDEO,
+							value: IeObjectType.VIDEO,
 							operator: Operator.CONTAINS,
 						},
 					],

--- a/src/modules/ie-objects/helpers/check-and-fix-format-filter.spec.ts
+++ b/src/modules/ie-objects/helpers/check-and-fix-format-filter.spec.ts
@@ -1,5 +1,5 @@
 import { IeObjectsSearchFilterField, Operator } from '../elasticsearch/elasticsearch.consts';
-import { MediaFormat } from '../ie-objects.types';
+import { IeObjectType } from '../ie-objects.types';
 
 import { checkAndFixFormatFilter } from './check-and-fix-format-filter';
 
@@ -9,12 +9,16 @@ describe('checkAndFixFormatFilter', () => {
 			filters: [
 				{
 					field: IeObjectsSearchFilterField.FORMAT,
-					value: MediaFormat.VIDEO,
+					value: IeObjectType.VIDEO,
 					operator: Operator.IS,
 				},
 			],
 		});
-		expect(fixedQuery.filters[0].multiValue).toEqual(['video', 'film']);
+		expect(fixedQuery.filters[0].multiValue).toEqual([
+			IeObjectType.VIDEO,
+			IeObjectType.FILM,
+			IeObjectType.VIDEO_FRAGMENT,
+		]);
 	});
 
 	it('should add film to a query on video in a multivalue', () => {
@@ -22,11 +26,15 @@ describe('checkAndFixFormatFilter', () => {
 			filters: [
 				{
 					field: IeObjectsSearchFilterField.FORMAT,
-					multiValue: [MediaFormat.VIDEO],
+					multiValue: [IeObjectType.VIDEO],
 					operator: Operator.IS,
 				},
 			],
 		});
-		expect(fixedQuery.filters[0].multiValue).toEqual(['video', 'film']);
+		expect(fixedQuery.filters[0].multiValue).toEqual([
+			IeObjectType.VIDEO,
+			IeObjectType.FILM,
+			IeObjectType.VIDEO_FRAGMENT,
+		]);
 	});
 });

--- a/src/modules/ie-objects/helpers/check-and-fix-format-filter.ts
+++ b/src/modules/ie-objects/helpers/check-and-fix-format-filter.ts
@@ -1,16 +1,29 @@
 import { find } from 'lodash';
 
 import { type IeObjectsQueryDto, type SearchFilter } from '../dto/ie-objects.dto';
-import { MediaFormat } from '../ie-objects.types';
+
+import { IeObjectType } from '~modules/ie-objects/ie-objects.types';
 
 export const checkAndFixFormatFilter = (queryDto: IeObjectsQueryDto | null): IeObjectsQueryDto => {
 	const formatFilter = find(queryDto?.filters || [], { field: 'format' }) as SearchFilter;
-	if (formatFilter?.value === MediaFormat.VIDEO) {
-		// change to multivalue with video and film
-		formatFilter.multiValue = ['video', 'film'];
+	if (formatFilter?.value === IeObjectType.VIDEO) {
+		// change to multivalue with video, film and video fragment
+		formatFilter.multiValue = [
+			IeObjectType.VIDEO,
+			IeObjectType.FILM,
+			IeObjectType.VIDEO_FRAGMENT,
+		];
 		delete formatFilter.value;
-	} else if (formatFilter?.multiValue?.includes(MediaFormat.VIDEO)) {
-		formatFilter.multiValue.push('film');
+	} else if (formatFilter?.multiValue?.includes(IeObjectType.VIDEO)) {
+		formatFilter.multiValue.push(IeObjectType.FILM);
+		formatFilter.multiValue.push(IeObjectType.VIDEO_FRAGMENT);
+	}
+	if (formatFilter?.value === IeObjectType.AUDIO) {
+		// change to multivalue with audio and audio fragment
+		formatFilter.multiValue = [IeObjectType.AUDIO, IeObjectType.AUDIO_FRAGMENT];
+		delete formatFilter.value;
+	} else if (formatFilter?.multiValue?.includes(IeObjectType.AUDIO)) {
+		formatFilter.multiValue.push(IeObjectType.AUDIO_FRAGMENT);
 	}
 	return queryDto;
 };

--- a/src/modules/ie-objects/ie-objects.types.ts
+++ b/src/modules/ie-objects/ie-objects.types.ts
@@ -14,11 +14,6 @@ export type IeObjectSeo = Pick<IeObject, 'name' | 'description' | 'thumbnailUrl'
 
 export type GqlLimitedIeObject = FindAllIeObjectsByFolderIdQuery['users_folder_ie'][0];
 
-export enum MediaFormat {
-	VIDEO = 'video',
-	AUDIO = 'audio',
-}
-
 export enum IeObjectLicense {
 	// Object Licenses
 	PUBLIEK_METADATA_LTD = 'VIAA-PUBLIEK-METADATA-LTD',
@@ -125,10 +120,12 @@ export interface IsPartOfCollection {
 }
 
 export enum IeObjectType {
-	Video = 'video',
-	Audio = 'audio',
-	Film = 'film',
-	Newspaper = 'newspaper',
+	VIDEO = 'video',
+	FILM = 'film', // This is considered video
+	VIDEO_FRAGMENT = 'videofragment', // This is considered video
+	AUDIO = 'audio',
+	AUDIO_FRAGMENT = 'audiofragment', // This is considered audio
+	NEWSPAPER = 'newspaper',
 }
 
 export interface IeObject {

--- a/src/modules/ie-objects/mocks/ie-objects.mock.ts
+++ b/src/modules/ie-objects/mocks/ie-objects.mock.ts
@@ -61,7 +61,7 @@ export const mockIeObject1: Readonly<IeObject> = {
 		'KARAKTERVORMING',
 	],
 	genre: ['program'],
-	dctermsFormat: IeObjectType.Video,
+	dctermsFormat: IeObjectType.VIDEO,
 	dctermsMedium: ['16mm'],
 	inLanguage: null,
 	thumbnailUrl:
@@ -111,7 +111,7 @@ export const mockIeObjectWithMetadataSetLTD: Readonly<Partial<IeObject>> = {
 	maintainerDescription:
 		'De Vlaamse Radio- en Televisieomroeporganisatie, afgekort VRT, is de Nederlandstalige openbare omroep voor radio en televisie in België.',
 	name: 'Durf te vragen R002 A0001',
-	dctermsFormat: IeObjectType.Video,
+	dctermsFormat: IeObjectType.VIDEO,
 	dctermsMedium: ['16mm'],
 	duration: '00:39:52',
 	dateCreated: '[2020-09-01]',
@@ -185,7 +185,7 @@ export const mockIeObjectWithMetadataSetALL: Readonly<Partial<IeObject>> = {
 			name: 'Programma1',
 		},
 	],
-	dctermsFormat: IeObjectType.Video,
+	dctermsFormat: IeObjectType.VIDEO,
 	dctermsMedium: ['16mm'],
 	duration: '00:39:52',
 	dateCreated: '[2020-09-01]',
@@ -257,7 +257,7 @@ export const mockIeObjectWithMetadataSetALLWithEssence: Readonly<Partial<IeObjec
 	maintainerDescription:
 		'De Vlaamse Radio- en Televisieomroeporganisatie, afgekort VRT, is de Nederlandstalige openbare omroep voor radio en televisie in België.',
 	name: 'Durf te vragen R002 A0001',
-	dctermsFormat: IeObjectType.Video,
+	dctermsFormat: IeObjectType.VIDEO,
 	dctermsMedium: ['16mm'],
 	ebucoreObjectType: null,
 	duration: '00:39:52',
@@ -340,7 +340,7 @@ export const mockIeObjectLimitedInFolder: Readonly<Partial<IeObject>> = {
 			name: 'Programma1',
 		},
 	],
-	dctermsFormat: IeObjectType.Video,
+	dctermsFormat: IeObjectType.VIDEO,
 	dctermsMedium: ['16mm'],
 	duration: '00:39:52',
 	dateCreated: '[2020-09-01]',
@@ -397,7 +397,7 @@ export const mockIeObjectDefaultLimitedMetadata: Readonly<Partial<IeObject>> = {
 			name: 'Programma1',
 		},
 	],
-	dctermsFormat: IeObjectType.Video,
+	dctermsFormat: IeObjectType.VIDEO,
 	datePublished: '2020-09-01',
 	meemooLocalId: null,
 	premisIdentifier: [
@@ -737,7 +737,7 @@ export const mockGqlIeObjectFindByFolderId: FindAllIeObjectsByFolderIdQuery['use
 export const mockGqlIeObjectFindByFolderIdResult: Readonly<Partial<IeObject>> = {
 	dateCreated: null,
 	datePublished: null,
-	dctermsFormat: IeObjectType.Video,
+	dctermsFormat: IeObjectType.VIDEO,
 	isPartOf: [
 		{
 			collectionType: 'reeks' as IsPartOfKey,

--- a/src/modules/ie-objects/services/ie-objects.service.spec.ts
+++ b/src/modules/ie-objects/services/ie-objects.service.spec.ts
@@ -9,7 +9,7 @@ import nock from 'nock';
 import { type Configuration } from '~config';
 
 import { IeObjectsSearchFilterField, Operator } from '../elasticsearch/elasticsearch.consts';
-import { type ElasticsearchResponse, IeObjectLicense } from '../ie-objects.types';
+import { type ElasticsearchResponse, IeObjectLicense, IeObjectType } from '../ie-objects.types';
 import {
 	mockChildrenIeObjects,
 	mockGqlIeObjectFindByFolderId,
@@ -141,8 +141,9 @@ describe('ieObjectsService', () => {
 				aggregations: {
 					dcterms_format: {
 						buckets: [
-							{ key: 'film', doc_count: 1 },
-							{ key: 'video', doc_count: 1 },
+							{ key: IeObjectType.VIDEO, doc_count: 1 },
+							{ key: IeObjectType.FILM, doc_count: 1 },
+							{ key: IeObjectType.VIDEO_FRAGMENT, doc_count: 1 },
 						],
 					},
 				},
@@ -156,13 +157,13 @@ describe('ieObjectsService', () => {
 			const esResponse = {
 				aggregations: {
 					dcterms_format: {
-						buckets: [{ key: 'film', doc_count: 1 }],
+						buckets: [{ key: IeObjectType.FILM, doc_count: 1 }],
 					},
 				},
 			} as ElasticsearchResponse;
 			const result = await ieObjectsService.adaptESResponse(esResponse, 'referer', '');
 			expect(result.aggregations.dcterms_format.buckets.length).toEqual(1);
-			expect(result.aggregations.dcterms_format.buckets[0].key).toEqual('video');
+			expect(result.aggregations.dcterms_format.buckets[0].key).toEqual(IeObjectType.VIDEO);
 			expect(result.aggregations.dcterms_format.buckets[0].doc_count).toEqual(1);
 		});
 	});

--- a/src/modules/material-requests/material-requests.types.ts
+++ b/src/modules/material-requests/material-requests.types.ts
@@ -5,7 +5,7 @@ import {
 	type Lookup_App_Material_Request_Requester_Capacity_Enum,
 	type Lookup_App_Material_Request_Type_Enum,
 } from '~generated/graphql-db-types-hetarchief';
-import { type MediaFormat } from '~modules/ie-objects/ie-objects.types';
+import { type IeObjectType } from '~modules/ie-objects/ie-objects.types';
 import { type Locale } from '~shared/types/types';
 
 export interface MaterialRequest {
@@ -13,7 +13,7 @@ export interface MaterialRequest {
 	objectSchemaIdentifier: string;
 	objectSchemaName: string;
 	objectMeemooLocalId?: string;
-	objectDctermsFormat: MediaFormat;
+	objectDctermsFormat: IeObjectType;
 	objectThumbnailUrl: string;
 	profileId: string;
 	reason: string;

--- a/src/modules/material-requests/mocks/material-requests.mocks.ts
+++ b/src/modules/material-requests/mocks/material-requests.mocks.ts
@@ -7,7 +7,7 @@ import {
 	Lookup_App_Material_Request_Requester_Capacity_Enum,
 	Lookup_App_Material_Request_Type_Enum,
 } from '~generated/graphql-db-types-hetarchief';
-import { MediaFormat } from '~modules/ie-objects/ie-objects.types';
+import { IeObjectType } from '~modules/ie-objects/ie-objects.types';
 import { GroupId, GroupName, Permission, type User } from '~modules/users/types';
 import { Idp } from '~shared/auth/auth.types';
 import { Locale } from '~shared/types/types';
@@ -112,7 +112,7 @@ export const mockMaterialRequest1: MaterialRequest = {
 	maintainerName: 'VRT',
 	maintainerSlug: 'vrt',
 	objectSchemaName: 'Onderzoekscommissie PFAS-PFOS 03-12-2021, 08u5§',
-	objectDctermsFormat: MediaFormat.AUDIO,
+	objectDctermsFormat: IeObjectType.AUDIO,
 	objectThumbnailUrl:
 		'VRT/b1f60efadf5243d78c7c91512adaa6cefe52723ff35848268894c7861d852b79/keyframes/keyframes_1_1/keyframe1.jpg',
 };
@@ -140,7 +140,7 @@ const mockMaterialRequest2: MaterialRequest = {
 	maintainerLogo: 'https://assets.viaa.be/images/OR-7h1dk9t',
 	maintainerSlug: 'vlaams-parlement',
 	objectSchemaName: 'Onderzoekscommissie PFAS-PFOS 03-12-2021, 08u5§',
-	objectDctermsFormat: MediaFormat.AUDIO,
+	objectDctermsFormat: IeObjectType.AUDIO,
 	objectThumbnailUrl:
 		'VRT/b1f60efadf5243d78c7c91512adaa6cefe52723ff35848268894c7861d852b79/keyframes/keyframes_1_1/keyframe1.jpg',
 };

--- a/src/modules/material-requests/services/material-requests.service.ts
+++ b/src/modules/material-requests/services/material-requests.service.ts
@@ -51,7 +51,7 @@ import {
 	type MaterialRequestEmailInfo,
 } from '~modules/campaign-monitor/campaign-monitor.types';
 import { CampaignMonitorService } from '~modules/campaign-monitor/services/campaign-monitor.service';
-import { type MediaFormat } from '~modules/ie-objects/ie-objects.types';
+import { type IeObjectType } from '~modules/ie-objects/ie-objects.types';
 import { type Organisation } from '~modules/organisations/organisations.types';
 import { OrganisationsService } from '~modules/organisations/services/organisations.service';
 import { SpacesService } from '~modules/spaces/services/spaces.service';
@@ -375,7 +375,7 @@ export class MaterialRequestsService {
 			objectSchemaIdentifier: graphQlMaterialRequest.object_schema_identifier,
 			objectSchemaName: graphQlMaterialRequest.intellectualEntity.schema_name,
 			objectDctermsFormat: graphQlMaterialRequest.intellectualEntity
-				.dcterms_format as MediaFormat,
+				.dcterms_format as IeObjectType,
 			objectThumbnailUrl:
 				graphQlMaterialRequest.intellectualEntity.schema_thumbnail_url?.[0] || null,
 			profileId: graphQlMaterialRequest.profile_id,


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-2583

![image](https://github.com/user-attachments/assets/c499b232-7862-4260-a24e-35b7f3736f5b)


There is still one more image in the elasticsearch that shouldn't be there
But i'll report that as a separate issue to meemoo