### PR TITLE
feat(search): show autocomplete values when focusing creator dropdown

### DIFF
--- a/src/modules/ie-objects/controllers/ie-objects.controller.ts
+++ b/src/modules/ie-objects/controllers/ie-objects.controller.ts
@@ -43,8 +43,8 @@ import {
 	IeObjectAccessThrough,
 	IeObjectLicense,
 	type IeObjectSeo,
-	IeObjectType,
 	type IeObjectsWithAggregations,
+	IeObjectType,
 	type RelatedIeObject,
 	type RelatedIeObjects,
 } from '../ie-objects.types';
@@ -56,12 +56,7 @@ import { logAndThrow } from '@meemoo/admin-core-api/dist/src/modules/shared/help
 import { mapLimit } from 'blend-promise-utils';
 import { EventsService } from '~modules/events/services/events.service';
 import { LogEventType } from '~modules/events/types';
-import {
-	ALL_INDEXES,
-	IeObjectsSearchFilterField,
-	Operator,
-	OrderProperty,
-} from '~modules/ie-objects/elasticsearch/elasticsearch.consts';
+import { ALL_INDEXES, IeObjectsSearchFilterField, Operator, OrderProperty, } from '~modules/ie-objects/elasticsearch/elasticsearch.consts';
 import { mapDcTermsFormatToSimpleType } from '~modules/ie-objects/helpers/map-dc-terms-format-to-simple-type';
 import { SessionUserEntity } from '~modules/users/classes/session-user';
 import { GroupName } from '~modules/users/types';
@@ -574,16 +569,13 @@ export class IeObjectsController {
 				},
 			});
 		}
-		if (!queryDto?.query) {
-			throw new BadRequestException('Body param query is required');
-		}
 		if (!queryDto?.filters) {
 			throw new BadRequestException('Body param filters is required');
 		}
-		return this.ieObjectsService.getMetadataAutocomplete(queryDto.field, queryDto.query, {
+		return this.ieObjectsService.getMetadataAutocomplete(queryDto.field, queryDto.query || '', {
 			filters: queryDto.filters,
 			page: 1,
-			size: 200,
+			size: 2000,
 			orderProp: OrderProperty.RELEVANCE,
 			orderDirection: SortDirection.desc,
 		});

--- a/src/modules/ie-objects/services/ie-objects.service.ts
+++ b/src/modules/ie-objects/services/ie-objects.service.ts
@@ -4,31 +4,14 @@ import { retry } from 'async';
 
 import { DataService, PlayerTicketService } from '@meemoo/admin-core-api';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import {
-	Inject,
-	Injectable,
-	InternalServerErrorException,
-	Logger,
-	NotFoundException,
-} from '@nestjs/common';
+import { Inject, Injectable, InternalServerErrorException, Logger, NotFoundException, } from '@nestjs/common';
 
 import { ConfigService } from '@nestjs/config';
 import { type IPagination, Pagination } from '@studiohyperdrive/pagination';
 import { mapLimit } from 'blend-promise-utils';
 import type { Cache } from 'cache-manager';
 import got, { type Got } from 'got';
-import {
-	compact,
-	find,
-	isArray,
-	isEmpty,
-	isNil,
-	kebabCase,
-	omitBy,
-	orderBy,
-	take,
-	uniq,
-} from 'lodash';
+import { compact, find, isArray, isEmpty, isNil, kebabCase, omitBy, orderBy, uniq } from 'lodash';
 
 import type { Configuration } from '~config';
 
@@ -52,10 +35,10 @@ import {
 	type IeObjectPages,
 	type IeObjectRepresentation,
 	type IeObjectSector,
-	IeObjectType,
 	type IeObjectsSitemap,
 	type IeObjectsVisitorSpaceInfo,
 	type IeObjectsWithAggregations,
+	IeObjectType,
 	type IsPartOfKey,
 	type Mention,
 	type RelatedIeObject,
@@ -107,16 +90,13 @@ import {
 	MAX_COUNT_SEARCH_RESULTS,
 } from '~modules/ie-objects/elasticsearch/elasticsearch.consts';
 import { AND } from '~modules/ie-objects/elasticsearch/queryBuilder.helpers';
-import {
-	type SearchTermParseResult,
-	convertStringToSearchTerms,
-} from '~modules/ie-objects/helpers/convert-string-to-search-terms';
+import { convertStringToSearchTerms, type SearchTermParseResult, } from '~modules/ie-objects/helpers/convert-string-to-search-terms';
 import { AUTOCOMPLETE_FIELD_TO_ES_FIELD_NAME } from '~modules/ie-objects/ie-objects.conts';
 import {
-	CACHE_KEY_PREFIX_IE_OBJECTS_SEARCH,
 	CACHE_KEY_PREFIX_IE_OBJECT_DETAIL,
 	CACHE_KEY_PREFIX_IE_OBJECT_PID_TO_ID,
 	CACHE_KEY_PREFIX_IE_OBJECT_THUMBNAIL,
+	CACHE_KEY_PREFIX_IE_OBJECTS_SEARCH,
 	IE_OBJECT_DETAIL_QUERIES,
 } from '~modules/ie-objects/services/ie-objects.service.consts';
 import {
@@ -1400,19 +1380,34 @@ export class IeObjectsService {
 		const esField = AUTOCOMPLETE_FIELD_TO_ES_FIELD_NAME[field];
 		esQuery._source = false;
 		esQuery.fields = [`${esField}.sayt`];
-		esQuery.size = 200; // Load more results, so we can remove the non unique entries
+		esQuery.size = 2000; // Load more results, so we can remove the non unique entries
+		const mustClauses = [];
+
+		// Only add multi_match if query exists
+		if (query && query.trim() !== '') {
+			mustClauses.push({
+				multi_match: {
+					query: query,
+					type: 'bool_prefix',
+					fields: [`${esField}.sayt`, `${esField}.sayt._2gram`, `${esField}.sayt._3gram`],
+				},
+			});
+		} else {
+			mustClauses.push({
+				exists: {
+					field: esField,
+				},
+			});
+		}
+
+		// Preserve existing query if it exists
+		if (esQuery.query) {
+			mustClauses.push(esQuery.query);
+		}
+
 		esQuery.query = {
 			bool: {
-				must: [
-					{
-						multi_match: {
-							query: query,
-							type: 'bool_prefix',
-							fields: [`${esField}.sayt`, `${esField}.sayt._2gram`, `${esField}.sayt._3gram`],
-						},
-					},
-					esQuery.query,
-				],
+				must: mustClauses.length ? mustClauses : [{ match_all: {} }],
 			},
 		};
 		if (field === AutocompleteField.newspaperSeriesName) {
@@ -1448,32 +1443,33 @@ export class IeObjectsService {
 		const queryParts = query.toLowerCase().split(' ');
 
 		// Map elasticsearch response to a list of unique strings
-		return take(
-			uniq(
-				response.hits?.hits?.flatMap((hit): string[] => {
-					const value = hit.fields[`${esField}.sayt`];
-					if (isArray(value)) {
-						// List of strings
-						let relevantValues: string[];
-						if (value.length > 1) {
-							// If there are multiple values, filter them based on the query parts
-							relevantValues = value.filter((v) =>
-								queryParts.every((queryPart) => v.toLowerCase().includes(queryPart))
-							);
-						} else {
-							relevantValues = value;
-						}
-
-						return relevantValues.map((v) => {
-							return v.trim();
-						});
+		const suggestions: string[] = uniq(
+			response.hits?.hits?.flatMap((hit): string[] => {
+				const value = hit.fields[`${esField}.sayt`];
+				if (isArray(value)) {
+					// List of strings
+					let relevantValues: string[];
+					if (value.length > 1) {
+						// If there are multiple values, filter them based on the query parts
+						relevantValues = value.filter((v) =>
+							queryParts.every((queryPart) => v.toLowerCase().includes(queryPart))
+						);
+					} else {
+						relevantValues = value;
 					}
-					// Single string
-					return [value] as string[];
-				})
-			),
-			200
+
+					return relevantValues.map((v) => {
+						return v.trim();
+					});
+				}
+				// Single string
+				return [value] as string[];
+			})
 		);
+		if (!query) {
+			return suggestions.sort();
+		}
+		return suggestions;
 	}
 
 	public async getPreviousNextIeObject(collectionId: string, ieObjectIri: string) {

--- a/src/modules/material-request-messages/controllers/material-request-messages.controller.ts
+++ b/src/modules/material-request-messages/controllers/material-request-messages.controller.ts
@@ -27,7 +27,10 @@ import archiver from 'archiver';
 import type { Response } from 'express';
 import { kebabCase } from 'lodash';
 import { Lookup_App_Material_Request_Message_Type_Enum } from '~generated/graphql-db-types-hetarchief';
-import { MaterialRequestAttachment, MaterialRequestMessage } from '~modules/material-request-messages/material-request-messages.types';
+import {
+	MaterialRequestAttachment,
+	MaterialRequestMessage,
+} from '~modules/material-request-messages/material-request-messages.types';
 import { MaterialRequest } from '~modules/material-requests/material-requests.types';
 import { MaterialRequestsService } from '~modules/material-requests/services/material-requests.service';
 import { SessionUserEntity } from '~modules/users/classes/session-user';

--- a/src/modules/material-request-messages/queries/getMaterialRequestAttachments.graphql
+++ b/src/modules/material-request-messages/queries/getMaterialRequestAttachments.graphql
@@ -1,9 +1,6 @@
 query getMaterialRequestAttachments($materialRequestId: uuid!, $offset: Int!, $limit: Int!) {
 	app_material_request_messages_and_events(
-		where: {
-			material_request_id: { _eq: $materialRequestId }
-			attachment_url: { _is_null: false }
-		}
+		where: { material_request_id: { _eq: $materialRequestId }, attachment_url: { _is_null: false } }
 		offset: $offset
 		limit: $limit
 		order_by: { created_at: asc }
@@ -14,10 +11,7 @@ query getMaterialRequestAttachments($materialRequestId: uuid!, $offset: Int!, $l
 		created_at
 	}
 	app_material_request_messages_and_events_aggregate(
-		where: {
-			material_request_id: { _eq: $materialRequestId }
-			attachment_url: { _is_null: false }
-		}
+		where: { material_request_id: { _eq: $materialRequestId }, attachment_url: { _is_null: false } }
 	) {
 		aggregate {
 			count

--- a/src/modules/material-request-messages/services/material-request-messages.service.ts
+++ b/src/modules/material-request-messages/services/material-request-messages.service.ts
@@ -1,7 +1,10 @@
 import { DataService } from '@meemoo/admin-core-api';
 import { Injectable } from '@nestjs/common';
 import { type IPagination, Pagination } from '@studiohyperdrive/pagination';
-import { MaterialRequestAttachment, MaterialRequestMessage } from '../material-request-messages.types';
+import {
+	MaterialRequestAttachment,
+	MaterialRequestMessage,
+} from '../material-request-messages.types';
 
 import {
 	CountUnreadMaterialRequestMessagesDocument,

--- a/src/modules/material-requests/services/material-requests.service.ts
+++ b/src/modules/material-requests/services/material-requests.service.ts
@@ -1,9 +1,24 @@
 import { parse } from 'node:path';
 import { DataService, Locale, StillsObjectType, VideoStillsService } from '@meemoo/admin-core-api';
-import { BadRequestException, Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
+import {
+	BadRequestException,
+	Injectable,
+	InternalServerErrorException,
+	NotFoundException,
+} from '@nestjs/common';
 import { type IPagination, Pagination } from '@studiohyperdrive/pagination';
 import { mapLimit } from 'blend-promise-utils';
-import { compact, groupBy, intersection, isArray, isEmpty, isNil, kebabCase, noop, set } from 'lodash';
+import {
+	compact,
+	groupBy,
+	intersection,
+	isArray,
+	isEmpty,
+	isNil,
+	kebabCase,
+	noop,
+	set,
+} from 'lodash';
 
 import {
 	CreateMaterialRequestDto,
@@ -78,7 +93,10 @@ import {
 	UpdateMaterialRequestStatusMutation,
 	UpdateMaterialRequestStatusMutationVariables,
 } from '~generated/graphql-db-types-hetarchief';
-import { EmailTemplate, type MaterialRequestEmailInfo } from '~modules/campaign-monitor/campaign-monitor.types';
+import {
+	EmailTemplate,
+	type MaterialRequestEmailInfo,
+} from '~modules/campaign-monitor/campaign-monitor.types';
 
 import { CampaignMonitorService } from '~modules/campaign-monitor/services/campaign-monitor.service';
 import {

--- a/src/modules/mediahaven-jobs-watcher/services/mediahaven-jobs-watcher.service.spec.ts
+++ b/src/modules/mediahaven-jobs-watcher/services/mediahaven-jobs-watcher.service.spec.ts
@@ -3,7 +3,10 @@ import { ConfigService } from '@nestjs/config';
 import { Test, type TestingModule } from '@nestjs/testing';
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 
-import { MamJobStatus, type MediahavenJobInfo } from '~modules/mediahaven-jobs-watcher/mediahaven-jobs-watcher.types';
+import {
+	MamJobStatus,
+	type MediahavenJobInfo,
+} from '~modules/mediahaven-jobs-watcher/mediahaven-jobs-watcher.types';
 import { MediahavenJobsWatcherService } from './mediahaven-jobs-watcher.service';
 
 import { Lookup_App_Material_Request_Download_Status_Enum } from '~generated/graphql-db-types-hetarchief';

--- a/src/modules/sitemap/services/sitemap.service.ts
+++ b/src/modules/sitemap/services/sitemap.service.ts
@@ -1,6 +1,11 @@
 import { Readable } from 'node:stream';
 
-import { AssetsService, ContentPagesService, DataService, DbContentPage } from '@meemoo/admin-core-api';
+import {
+	AssetsService,
+	ContentPagesService,
+	DataService,
+	DbContentPage,
+} from '@meemoo/admin-core-api';
 import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { format } from 'date-fns';
 import { compact, kebabCase, uniqBy } from 'lodash';


### PR DESCRIPTION
F62: als gebruiker wil ik bij de filters “Maker”/ “Namenlijst
gesneuvelden“ / “Reeks”/ “Plaats van uitgave” kunnen scrollen in
een searchable dropdown zodat ik een overzicht heb van welke
mogelijke waarden er zijn, maar ook gericht kan zoeken. 