### PR TITLE
fix(ARC-3599): fix advanced filter for rights for newspapers and AV obj

### DIFF
--- a/elasticsearch-local/mapping-without-matchbox.json
+++ b/elasticsearch-local/mapping-without-matchbox.json
@@ -74,6 +74,18 @@
     "premis_is_part_of": {
       "type": "keyword"
     },
+    "reuse_category": {
+      "properties": {
+        "id": {
+          "type": "keyword",
+          "normalizer": "lowercase"
+        },
+        "label": {
+          "type": "keyword",
+          "index": false
+        }
+      }
+    },
     "schema_abstract": {
       "type": "text",
       "fields": {

--- a/src/modules/ie-objects/elasticsearch/elasticsearch.consts.ts
+++ b/src/modules/ie-objects/elasticsearch/elasticsearch.consts.ts
@@ -348,11 +348,17 @@ export const MULTI_MATCH_FIELDS: Array<IeObjectsSearchFilterField> = [
 	IeObjectsSearchFilterField.IDENTIFIER,
 ];
 
-export const OCCURRENCE_TYPE: { [prop in Operator]?: string } = {
-	contains: 'must',
-	containsNot: 'must_not',
-	is: 'must',
-	isNot: 'must_not',
+export enum OccurenceType {
+	must = 'must',
+	must_not = 'must_not',
+	filter = 'filter',
+}
+
+export const OCCURRENCE_TYPE: { [prop in Operator]?: OccurenceType } = {
+	contains: OccurenceType.must,
+	containsNot: OccurenceType.must_not,
+	is: OccurenceType.must,
+	isNot: OccurenceType.must_not,
 };
 
 export const VALUE_OPERATORS: Operator[] = [Operator.GTE, Operator.LTE];

--- a/src/modules/ie-objects/elasticsearch/elasticsearch.consts.ts
+++ b/src/modules/ie-objects/elasticsearch/elasticsearch.consts.ts
@@ -38,7 +38,7 @@ export enum IeObjectsSearchFilterField {
 	CONSULTABLE_MEDIA = 'isConsultableMedia',
 	CONSULTABLE_PUBLIC_DOMAIN = 'isConsultablePublicDomain',
 	REUSABILITY = 'reusability',
-	RIGHTS = 'rights',
+	RIGHTS = 'rights', // Single term to cover both newspaper rights (dcterms_rights_statement) and Audio/Video object rights (reuse_category.id)
 	CAST = 'cast',
 	IDENTIFIER = 'identifier',
 	CATEGORIE = 'categorie', // Not available in database: https://docs.google.com/spreadsheets/d/1xAtHfkpDi4keSsBol7pw0cQAvCmg2hWRz8oxM6cP7zo/edit#gid=0
@@ -282,6 +282,8 @@ export enum ElasticsearchField {
 	newspaper = 'newspaper',
 	schema_location_created = 'schema_location_created',
 	dcterms_rights_statement = 'dcterms_rights_statement',
+	reuse_category = 'reuse_category',
+	id = 'id',
 }
 
 export const READABLE_TO_ELASTIC_FILTER_NAMES: {
@@ -291,6 +293,7 @@ export const READABLE_TO_ELASTIC_FILTER_NAMES: {
 		| IeObjectsSearchFilterField.CONSULTABLE_MEDIA
 		| IeObjectsSearchFilterField.CONSULTABLE_PUBLIC_DOMAIN
 		| IeObjectsSearchFilterField.REUSABILITY
+		| IeObjectsSearchFilterField.RIGHTS // RIGHTS is a special case, since we need to search through 2 fields: dcterms_rights_statement and reuse_category.id
 		| IeObjectsSearchFilterField.RELEASE_DATE // Custom filter: creation date OR publish date
 	>]: ElasticsearchField | `${ElasticsearchField}.${ElasticsearchField}`;
 } = {
@@ -320,7 +323,6 @@ export const READABLE_TO_ELASTIC_FILTER_NAMES: {
 	[IeObjectsSearchFilterField.OBJECT_TYPE]: ElasticsearchField.ebucore_object_type,
 	[IeObjectsSearchFilterField.IDENTIFIER]: ElasticsearchField.schema_identifier,
 	[IeObjectsSearchFilterField.LICENSES]: ElasticsearchField.schema_license,
-	[IeObjectsSearchFilterField.RIGHTS]: ElasticsearchField.dcterms_rights_statement,
 };
 
 export const NUMBER_OF_FILTER_OPTIONS_DEFAULT = 40;
@@ -330,7 +332,6 @@ export const NUMBER_OF_OPTIONS_PER_AGGREGATE = {
 	[IeObjectsSearchFilterField.MEDIUM]: 500, // Fetch all options at once
 	[IeObjectsSearchFilterField.LANGUAGE]: 500, // Fetch all options at once
 	[IeObjectsSearchFilterField.MAINTAINER_ID]: 500, // Fetch all options at once
-	[IeObjectsSearchFilterField.RIGHTS]: 500, // Fetch all options at once
 };
 
 export const ORDER_MAPPINGS: { [prop in OrderProperty]: string } = {

--- a/src/modules/ie-objects/elasticsearch/queryBuilder.spec.ts
+++ b/src/modules/ie-objects/elasticsearch/queryBuilder.spec.ts
@@ -340,6 +340,26 @@ describe('QueryBuilder', () => {
 			});
 		});
 
+		it('should create two separate aggregations for the RIGHTS field', () => {
+			const esQuery = QueryBuilder.build(
+				{
+					filters: [],
+					size: 10,
+					page: 1,
+					requestedAggs: [IeObjectsSearchFilterField.RIGHTS],
+				},
+				mockInputInfo as any
+			);
+			expect(esQuery.aggs.dcterms_rights_statement.terms).toEqual({
+				field: 'dcterms_rights_statement',
+				size: 500,
+			});
+			expect(esQuery.aggs['reuse_category.id'].terms).toEqual({
+				field: 'reuse_category.id',
+				size: 500,
+			});
+		});
+
 		it('should sort on a given order property', () => {
 			const orderProp = OrderProperty.NAME;
 			const orderDirection = SortDirection.asc;
@@ -612,8 +632,8 @@ describe('QueryBuilder', () => {
 				mockInputInfo as any
 			);
 			const queryString = JSON.stringify(queryObject);
-			expect(queryString).toContain('dcterms_rights_statement');
-			expect(queryString).toContain('reuse_category');
+			expect(queryString).toContain('"dcterms_rights_statement":');
+			expect(queryString).toContain('"reuse_category.id":');
 			expect(queryString).toContain('https://creativecommons.org/publicdomain/mark/1.0/');
 			// Should not include URIs from other categories
 			expect(queryString).not.toContain('https://rightsstatements.org/page/InC/1.0/');
@@ -643,7 +663,7 @@ describe('QueryBuilder', () => {
 			expect(queryString).toContain('https://rightsstatements.org/page/UND/1.0/');
 			expect(queryString).toContain('REUSABILITY_DCTERMS_RIGHTS_STATEMENT_NEWSPAPERS');
 			expect(queryString).toContain('REUSABILITY_REUSE_CATEGORY_AUDIO_VIDEO');
-			expect(queryString).toContain('reuse_category');
+			expect(queryString).toContain('"reuse_category.id":');
 		});
 
 		it('Should apply reusability filters in the public limited metadata branch', () => {
@@ -666,7 +686,7 @@ describe('QueryBuilder', () => {
 			expect(publicLimitedBranch).toContain('PUBLIC-METDATA_LTD');
 			expect(publicLimitedBranch).toContain('REUSABILITY_DCTERMS_RIGHTS_STATEMENT_NEWSPAPERS');
 			expect(publicLimitedBranch).toContain('REUSABILITY_REUSE_CATEGORY_AUDIO_VIDEO');
-			expect(publicLimitedBranch).toContain('reuse_category');
+			expect(publicLimitedBranch).toContain('"reuse_category.id":');
 			expect(publicLimitedBranch).toContain('https://rightsstatements.org/page/UND/1.0/');
 		});
 
@@ -708,7 +728,7 @@ describe('QueryBuilder', () => {
 			const queryString = JSON.stringify(queryObject);
 			expect(queryString).toContain('REUSABILITY_DCTERMS_RIGHTS_STATEMENT_NEWSPAPERS');
 			expect(queryString).toContain('REUSABILITY_REUSE_CATEGORY_AUDIO_VIDEO');
-			expect(queryString).toContain('reuse_category');
+			expect(queryString).toContain('"reuse_category.id":');
 			expect(queryString).toContain('https://rightsstatements.org/page/NoC-CR/1.0/');
 		});
 
@@ -752,6 +772,8 @@ describe('QueryBuilder', () => {
 			const queryString = JSON.stringify(queryObject);
 			expect(queryString).toContain('RIGHTS_DCTERMS_RIGHTS_STATEMENT_FOR_NEWSPAPERS');
 			expect(queryString).toContain('RIGHTS_REUSE_CATEGORY_FOR_AUDIO_VIDEO');
+			expect(queryString).toContain('"dcterms_rights_statement":');
+			expect(queryString).toContain('"reuse_category.id":');
 			expect(queryString).toContain('https://creativecommons.org/publicdomain/mark/1.0/');
 			expect(queryString).toContain('https://creativecommons.org/publicdomain/zero/1.0/');
 		});
@@ -775,6 +797,8 @@ describe('QueryBuilder', () => {
 			const queryString = JSON.stringify(queryObject);
 			expect(queryString).toContain('RIGHTS_DCTERMS_RIGHTS_STATEMENT_FOR_NEWSPAPERS');
 			expect(queryString).toContain('RIGHTS_REUSE_CATEGORY_FOR_AUDIO_VIDEO');
+			expect(queryString).toContain('"dcterms_rights_statement":');
+			expect(queryString).toContain('"reuse_category.id":');
 			expect(queryString).toContain('unknown-rights-label');
 		});
 
@@ -795,6 +819,8 @@ describe('QueryBuilder', () => {
 			);
 			const queryString = JSON.stringify(queryObject);
 			expect(queryString).toContain('must_not');
+			expect(queryString).toContain('"dcterms_rights_statement":');
+			expect(queryString).toContain('"reuse_category.id":');
 			expect(queryString).toContain('https://rightsstatements.org/page/InC/1.0/');
 		});
 

--- a/src/modules/ie-objects/elasticsearch/queryBuilder.spec.ts
+++ b/src/modules/ie-objects/elasticsearch/queryBuilder.spec.ts
@@ -750,7 +750,8 @@ describe('QueryBuilder', () => {
 				mockInputInfo as any
 			);
 			const queryString = JSON.stringify(queryObject);
-			expect(queryString).toContain('RIGHTS_DCTERMS_RIGHTS_STATEMENT');
+			expect(queryString).toContain('RIGHTS_DCTERMS_RIGHTS_STATEMENT_FOR_NEWSPAPERS');
+			expect(queryString).toContain('RIGHTS_REUSE_CATEGORY_FOR_AUDIO_VIDEO');
 			expect(queryString).toContain('https://creativecommons.org/publicdomain/mark/1.0/');
 			expect(queryString).toContain('https://creativecommons.org/publicdomain/zero/1.0/');
 		});
@@ -772,7 +773,8 @@ describe('QueryBuilder', () => {
 			);
 
 			const queryString = JSON.stringify(queryObject);
-			expect(queryString).toContain('RIGHTS_DCTERMS_RIGHTS_STATEMENT');
+			expect(queryString).toContain('RIGHTS_DCTERMS_RIGHTS_STATEMENT_FOR_NEWSPAPERS');
+			expect(queryString).toContain('RIGHTS_REUSE_CATEGORY_FOR_AUDIO_VIDEO');
 			expect(queryString).toContain('unknown-rights-label');
 		});
 

--- a/src/modules/ie-objects/elasticsearch/queryBuilder.ts
+++ b/src/modules/ie-objects/elasticsearch/queryBuilder.ts
@@ -288,7 +288,7 @@ export class QueryBuilder {
 				occurrenceType: OCCURRENCE_TYPE[searchFilter.operator],
 				query: {
 					term: {
-						'schema_creator_text.keyword': searchFilter.value,
+						[`${ElasticsearchField.schema_creator}.keyword`]: searchFilter.value,
 					},
 				},
 			};
@@ -301,7 +301,7 @@ export class QueryBuilder {
 			FLATTENED_FIELDS.includes(searchFilter.field) &&
 			[Operator.CONTAINS, Operator.CONTAINS_NOT].includes(searchFilter.operator)
 		) {
-			// Publisher/Creator are a special cases since they are flattened fields
+			// Publisher/Creator are special cases since they are flattened fields
 			return {
 				occurrenceType: OCCURRENCE_TYPE[searchFilter.operator],
 				query: {
@@ -349,7 +349,7 @@ export class QueryBuilder {
 		const queryType: QueryType = QueryBuilder.getQueryType(searchFilter, value);
 
 		// Append .keyword if needed
-		const queryKey = elasticKey + QueryBuilder.filterSuffix(searchFilter.field);
+		const queryKey = elasticKeyResolved + QueryBuilder.filterSuffix(searchFilter.field);
 
 		return {
 			occurrenceType,
@@ -504,6 +504,33 @@ export class QueryBuilder {
 				throw new BadRequestException(
 					`Field '${searchFilter.field}' cannot be queried with the '${searchFilter.operator}' operator.`
 				);
+			}
+
+			/**
+			 * RIGHTS is a special case, since we need to look through 2 fields for this filter:
+			 * - dcterms_rights_statement
+			 * - reuse_category.id
+			 */
+			if (searchFilter.field === IeObjectsSearchFilterField.RIGHTS) {
+				applyFilter(filterObject, {
+					occurrenceType: OCCURRENCE_TYPE[searchFilter.operator],
+					query: [
+						{
+							terms: {
+								_name: 'RIGHTS_DCTERMS_RIGHTS_STATEMENT',
+								[ElasticsearchField.dcterms_rights_statement]: searchFilter.multiValue,
+							},
+						},
+						{
+							terms: {
+								_name: 'REUSE_CATEGORY_FOR_AUDIO_VIDEO',
+								[`${ElasticsearchField.reuse_category}.${ElasticsearchField.id}`]:
+									searchFilter.multiValue,
+							},
+						},
+					],
+				});
+				continue;
 			}
 
 			// Map frontend filter names to elasticsearch names
@@ -695,9 +722,22 @@ export class QueryBuilder {
 			const rightsQueries = [
 				rightsStatementUris.length
 					? {
-							terms: {
-								_name: 'RIGHTS_DCTERMS_RIGHTS_STATEMENT',
-								dcterms_rights_statement: rightsStatementUris,
+							bool: {
+								should: [
+									{
+										terms: {
+											_name: 'RIGHTS_DCTERMS_RIGHTS_STATEMENT_FOR_NEWSPAPERS',
+											dcterms_rights_statement: rightsStatementUris,
+										},
+									},
+									{
+										terms: {
+											_name: 'RIGHTS_REUSE_CATEGORY_FOR_AUDIO_VIDEO',
+											'reuse_category.id': rightsStatementUris,
+										},
+									},
+								],
+								minimum_should_match: 1,
 							},
 						}
 					: null,
@@ -986,6 +1026,21 @@ export class QueryBuilder {
 		forEach(searchRequest.requestedAggs || AGGS_PROPERTIES, (aggProperty) => {
 			const elasticProperty =
 				READABLE_TO_ELASTIC_FILTER_NAMES[aggProperty as IeObjectsSearchFilterField];
+			if (aggProperty === IeObjectsSearchFilterField.RIGHTS) {
+				aggs[ElasticsearchField.dcterms_rights_statement] = {
+					terms: {
+						field: ElasticsearchField.dcterms_rights_statement,
+						size: 500,
+					},
+				};
+				aggs[`${ElasticsearchField.reuse_category}.${ElasticsearchField.id}`] = {
+					terms: {
+						field: `${ElasticsearchField.reuse_category}.${ElasticsearchField.id}`,
+						size: 500,
+					},
+				};
+				return;
+			}
 			if (!elasticProperty) {
 				throw new InternalServerErrorException(`Failed to resolve agg property: ${aggProperty}`);
 			}

--- a/src/modules/ie-objects/elasticsearch/queryBuilder.ts
+++ b/src/modules/ie-objects/elasticsearch/queryBuilder.ts
@@ -288,7 +288,7 @@ export class QueryBuilder {
 				occurrenceType: OCCURRENCE_TYPE[searchFilter.operator],
 				query: {
 					term: {
-						[`${ElasticsearchField.schema_creator}.keyword`]: searchFilter.value,
+						[`${ElasticsearchField.schema_creator}_text.keyword`]: searchFilter.value,
 					},
 				},
 			};
@@ -319,6 +319,9 @@ export class QueryBuilder {
 			[Operator.IS, Operator.IS_NOT].includes(searchFilter.operator)
 		) {
 			elasticKeyResolved = `${elasticKey}.keyword`;
+		} else {
+			// Append .keyword if needed
+			elasticKeyResolved = elasticKeyResolved + QueryBuilder.filterSuffix(searchFilter.field);
 		}
 
 		// Contains, ContainsNot
@@ -348,14 +351,11 @@ export class QueryBuilder {
 		// term, terms, range, match, query_string
 		const queryType: QueryType = QueryBuilder.getQueryType(searchFilter, value);
 
-		// Append .keyword if needed
-		const queryKey = elasticKeyResolved + QueryBuilder.filterSuffix(searchFilter.field);
-
 		return {
 			occurrenceType,
 			query: {
 				[queryType]: {
-					[queryKey]: value,
+					[elasticKeyResolved]: value,
 				},
 			},
 		};
@@ -399,9 +399,9 @@ export class QueryBuilder {
 				},
 			});
 		}
-		// Determine consultable filters are present and strip them from standard filter list to be processed later on
+		// Determine consultable filters are present and strip them from the standard filter list to be processed later on
 		// Remark: this needs to happen after the line that checks if filters are empty.
-		// This because if we strip it before it will just return match_all
+		// This because if we strip it earlier, it will just return match_all
 		const customSearchFilterFields: IeObjectsSearchFilterField[] = [
 			IeObjectsSearchFilterField.CONSULTABLE_ONLY_ON_LOCATION,
 			IeObjectsSearchFilterField.CONSULTABLE_MEDIA,
@@ -504,33 +504,6 @@ export class QueryBuilder {
 				throw new BadRequestException(
 					`Field '${searchFilter.field}' cannot be queried with the '${searchFilter.operator}' operator.`
 				);
-			}
-
-			/**
-			 * RIGHTS is a special case, since we need to look through 2 fields for this filter:
-			 * - dcterms_rights_statement
-			 * - reuse_category.id
-			 */
-			if (searchFilter.field === IeObjectsSearchFilterField.RIGHTS) {
-				applyFilter(filterObject, {
-					occurrenceType: OCCURRENCE_TYPE[searchFilter.operator],
-					query: [
-						{
-							terms: {
-								_name: 'RIGHTS_DCTERMS_RIGHTS_STATEMENT',
-								[ElasticsearchField.dcterms_rights_statement]: searchFilter.multiValue,
-							},
-						},
-						{
-							terms: {
-								_name: 'REUSE_CATEGORY_FOR_AUDIO_VIDEO',
-								[`${ElasticsearchField.reuse_category}.${ElasticsearchField.id}`]:
-									searchFilter.multiValue,
-							},
-						},
-					],
-				});
-				continue;
 			}
 
 			// Map frontend filter names to elasticsearch names
@@ -719,6 +692,12 @@ export class QueryBuilder {
 				? rightsFilter.multiValue
 				: [rightsFilter.value as RightsLabel];
 			const rightsStatementUris = uniq(compact(rightsValues)) as RightsLabel[];
+
+			/**
+			 * RIGHTS is a special case, since we need to look through 2 fields for this filter:
+			 * - dcterms_rights_statement
+			 * - reuse_category.id
+			 */
 			const rightsQueries = [
 				rightsStatementUris.length
 					? {

--- a/src/modules/ie-objects/elasticsearch/queryBuilder.ts
+++ b/src/modules/ie-objects/elasticsearch/queryBuilder.ts
@@ -25,6 +25,7 @@ import {
 	NEEDS_FILTER_SUFFIX,
 	NUMBER_OF_FILTER_OPTIONS_DEFAULT,
 	NUMBER_OF_OPTIONS_PER_AGGREGATE,
+	OccurenceType,
 	OCCURRENCE_TYPE,
 	Operator,
 	ORDER_MAPPINGS,
@@ -255,8 +256,8 @@ export class QueryBuilder {
 		return sortArray;
 	}
 
-	private static getOccurrenceType(operator: Operator): string {
-		return OCCURRENCE_TYPE[operator] || 'filter';
+	private static getOccurrenceType(operator: Operator): OccurenceType {
+		return OCCURRENCE_TYPE[operator] || OccurenceType.filter;
 	}
 
 	private static buildValue(searchFilter: SearchFilter): any {
@@ -699,32 +700,24 @@ export class QueryBuilder {
 			 * - reuse_category.id
 			 */
 			const rightsQueries = [
-				rightsStatementUris.length
-					? {
-							bool: {
-								should: [
-									{
-										terms: {
-											_name: 'RIGHTS_DCTERMS_RIGHTS_STATEMENT_FOR_NEWSPAPERS',
-											dcterms_rights_statement: rightsStatementUris,
-										},
-									},
-									{
-										terms: {
-											_name: 'RIGHTS_REUSE_CATEGORY_FOR_AUDIO_VIDEO',
-											'reuse_category.id': rightsStatementUris,
-										},
-									},
-								],
-								minimum_should_match: 1,
-							},
-						}
-					: null,
+				{
+					terms: {
+						_name: 'RIGHTS_DCTERMS_RIGHTS_STATEMENT_FOR_NEWSPAPERS',
+						[ElasticsearchField.dcterms_rights_statement]: rightsStatementUris,
+					},
+				},
+				{
+					terms: {
+						_name: 'RIGHTS_REUSE_CATEGORY_FOR_AUDIO_VIDEO',
+						[`${ElasticsearchField.reuse_category}.${ElasticsearchField.id}`]: rightsStatementUris,
+					},
+				},
 			];
 
+			const occurrenceType = QueryBuilder.getOccurrenceType(rightsFilter.operator);
 			toBeAppliedCustomFilters.push({
-				occurrenceType: QueryBuilder.getOccurrenceType(rightsFilter.operator),
-				query: [OR(rightsQueries) ?? { match_none: { _name: 'RIGHTS' } }],
+				occurrenceType,
+				query: occurrenceType === OccurenceType.must_not ? rightsQueries : OR(rightsQueries),
 			});
 		}
 


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-3599

ensure both rights of newspapers and audio/video objects are shown in the advanced rights filter dropdown

<img width="2550" height="1393" alt="image" src="https://github.com/user-attachments/assets/a98adff1-37ac-4db9-a16e-9d8759af8e92" />
