### PR TITLE
fix(ARC-3690): remove cut fragments from main video page

### DIFF
--- a/src/modules/ie-objects/controllers/ie-objects.controller.spec.ts
+++ b/src/modules/ie-objects/controllers/ie-objects.controller.spec.ts
@@ -1,8 +1,4 @@
-import {
-	PlayerTicketController,
-	PlayerTicketService,
-	TranslationsService,
-} from '@meemoo/admin-core-api';
+import { PlayerTicketController, PlayerTicketService, TranslationsService, } from '@meemoo/admin-core-api';
 import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Test, type TestingModule } from '@nestjs/testing';
@@ -11,12 +7,7 @@ import type { Request, Response } from 'express';
 import { cloneDeep } from 'lodash';
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 
-import {
-	type IeObject,
-	IeObjectLicense,
-	IeObjectType,
-	type RelatedIeObject,
-} from '../ie-objects.types';
+import { type IeObject, IeObjectLicense, IeObjectType, type RelatedIeObject, } from '../ie-objects.types';
 import {
 	mockIeObject1,
 	mockIeObjectWithMetadataSetALL,
@@ -64,7 +55,7 @@ const mockIeObjectsService: Partial<Record<keyof IeObjectsService, MockInstance>
 		visitorSpaceIds: [],
 	})),
 	getObjectIdBySchemaIdentifierCached: vi.fn().mockResolvedValue('mock-ie-object-id'),
-	getFileInIeObject: vi.fn(),
+	getRepresentationAndFileInIeObject: vi.fn(),
 };
 
 const mockPlayerTicketService: Partial<Record<keyof PlayerTicketService, MockInstance>> = {
@@ -200,11 +191,14 @@ describe('IeObjectsController', () => {
 				},
 			] as Partial<IeObject>[]);
 			mockPlayerTicketService.getPlayableUrl.mockResolvedValueOnce('http://playme');
-			mockIeObjectsService.getFileInIeObject.mockReturnValueOnce({
-				id: 'website/id/entity/file-id',
-				storedAt: '/path/to/file',
-				mimeType: 'video/mp4',
-			});
+			mockIeObjectsService.getRepresentationAndFileInIeObject.mockReturnValueOnce([
+				{
+					id: 'website/id/entity/file-id',
+					storedAt: '/path/to/file',
+					mimeType: 'video/mp4',
+				},
+				{ id: 'representation-id' },
+			]);
 			const url = await ieObjectsController.getPlayableUrl(
 				'referer',
 				'127.0.0.1',

--- a/src/modules/ie-objects/controllers/ie-objects.controller.ts
+++ b/src/modules/ie-objects/controllers/ie-objects.controller.ts
@@ -123,11 +123,22 @@ export class IeObjectsController {
 				playerTicketsQuery.fileId
 			);
 
+		if (!requestedFile || !requestedRepresentation) {
+			throw new CustomError(
+				"Failed to find requested file and/or it's representation in ie-object",
+				null,
+				{
+					playerTicketsQuery,
+				},
+				404
+			);
+		}
+
 		// Check if we need to cut the video / audio file
 		// https://meemoo.atlassian.net/browse/ARC-3690?focusedCommentId=87432
 		let startTime: number | undefined;
 		let endTime: number | undefined;
-		if (requestedRepresentation.isMediaFragmentOf) {
+		if (requestedRepresentation?.isMediaFragmentOf) {
 			// Cut fragment => cut
 			startTime = requestedFile?.mediaFragment?.startTime ?? undefined;
 			endTime = requestedFile?.mediaFragment?.endTime ?? undefined;
@@ -1100,7 +1111,7 @@ export class IeObjectsController {
 						);
 
 						if (this.configService.get('IE_OBJECT_LOG_ACCESS_CHECKS') === 'true') {
-							console.log('fetching ie-object (before limiting): ', JSON.stringify(ieObject));
+							console.info('fetching ie-object (before limiting): ', JSON.stringify(ieObject));
 						}
 
 						if (!ieObject) {
@@ -1120,7 +1131,7 @@ export class IeObjectsController {
 						});
 
 						if (this.configService.get('IE_OBJECT_LOG_ACCESS_CHECKS') === 'true') {
-							console.log('fetching ie-object (after limiting): ', JSON.stringify(limitedObject));
+							console.info('fetching ie-object (after limiting): ', JSON.stringify(limitedObject));
 						}
 
 						if (!limitedObject) {
@@ -1156,10 +1167,10 @@ export class IeObjectsController {
 
 			return limitedObjects;
 		} catch (err) {
-			console.log('error', JSON.stringify(err));
+			console.error('error', JSON.stringify(err));
 			const errorJson = JSON.stringify(err);
 			if (errorJson.includes(ERROR_CODE.USER_NO_ACCESS_TO_IE_OBJECT)) {
-				console.log(
+				console.error(
 					new CustomError('has USER_NO_ACCESS_TO_IE_OBJECT code', err, {
 						schemaIdentifiers,
 						ieObjectIds,
@@ -1181,7 +1192,7 @@ export class IeObjectsController {
 				referer,
 				ip,
 			});
-			console.log(error);
+			console.error(error);
 			throw error;
 		}
 	}

--- a/src/modules/ie-objects/controllers/ie-objects.controller.ts
+++ b/src/modules/ie-objects/controllers/ie-objects.controller.ts
@@ -66,12 +66,7 @@ import { CustomError } from '@meemoo/admin-core-api/dist/src/modules/shared/help
 import { mapLimit } from 'blend-promise-utils';
 import { EventsService } from '~modules/events/services/events.service';
 import { LogEventType } from '~modules/events/types';
-import {
-	ALL_INDEXES,
-	IeObjectsSearchFilterField,
-	Operator,
-	OrderProperty,
-} from '~modules/ie-objects/elasticsearch/elasticsearch.consts';
+import { ALL_INDEXES, IeObjectsSearchFilterField, Operator, OrderProperty, } from '~modules/ie-objects/elasticsearch/elasticsearch.consts';
 import { mapDcTermsFormatToSimpleType } from '~modules/ie-objects/helpers/map-dc-terms-format-to-simple-type';
 import { ERROR_CODE, IE_OBJECT_AV_TYPES } from '~modules/ie-objects/ie-objects.conts';
 import { SessionUserEntity } from '~modules/users/classes/session-user';
@@ -122,16 +117,31 @@ export class IeObjectsController {
 			ip
 		);
 
-		const requestedFile = this.ieObjectsService.getFileInIeObject(
-			accessibleObject,
-			playerTicketsQuery.fileId
-		);
+		const [requestedFile, requestedRepresentation] =
+			this.ieObjectsService.getRepresentationAndFileInIeObject(
+				accessibleObject,
+				playerTicketsQuery.fileId
+			);
+
+		// Check if we need to cut the video / audio file
+		// https://meemoo.atlassian.net/browse/ARC-3690?focusedCommentId=87432
+		let startTime: number | undefined;
+		let endTime: number | undefined;
+		if (requestedRepresentation.isMediaFragmentOf) {
+			// Cut fragment => cut
+			startTime = requestedFile?.mediaFragment?.startTime ?? undefined;
+			endTime = requestedFile?.mediaFragment?.endTime ?? undefined;
+		} else {
+			// Main object => do not cut even if there is a start and end time
+			startTime = undefined;
+			endTime = undefined;
+		}
 		return this.playerTicketService.getPlayableUrl(requestedFile.storedAt, {
 			referer,
 			ip,
 			isPublicDomain: false,
-			startTime: requestedFile?.startTime ?? undefined,
-			endTime: requestedFile?.endTime ?? undefined,
+			startTime,
+			endTime,
 		});
 	}
 

--- a/src/modules/ie-objects/elasticsearch/queryBuilder.ts
+++ b/src/modules/ie-objects/elasticsearch/queryBuilder.ts
@@ -1,9 +1,22 @@
 import { BadRequestException, InternalServerErrorException } from '@nestjs/common';
 import jsep from 'jsep';
-import { clamp, compact, forEach, groupBy, intersection, isArray, isEmpty, isNil, uniq, } from 'lodash';
+import {
+	clamp,
+	compact,
+	forEach,
+	groupBy,
+	intersection,
+	isArray,
+	isEmpty,
+	isNil,
+	uniq,
+} from 'lodash';
 
 import { IeObjectsQueryDto, SearchFilter } from '../dto/ie-objects.dto';
-import { buildFreeTextFilter, convertNodeToEsQueryFilterObjects, } from '../helpers/convert-node-to-es-query-filter-objects';
+import {
+	buildFreeTextFilter,
+	convertNodeToEsQueryFilterObjects,
+} from '../helpers/convert-node-to-es-query-filter-objects';
 import { encodeSearchterm } from '../helpers/encode-search-term';
 import { IE_OBJECT_METADATA_SET_BY_OBJECT_AND_USER_SECTOR } from '../ie-objects.conts';
 import { IeObjectLicense, type IeObjectSector } from '../ie-objects.types';

--- a/src/modules/ie-objects/helpers/limit-access-to-object-details.ts
+++ b/src/modules/ie-objects/helpers/limit-access-to-object-details.ts
@@ -22,7 +22,7 @@ export const limitAccessToObjectDetails = (
 	userInfo: LimitAccessUserInfo
 ): Partial<IeObject> => {
 	if (process.env.IE_OBJECT_LOG_ACCESS_CHECKS === 'true') {
-		console.log('limit access to ie-object with user info: ', JSON.stringify(userInfo));
+		console.info('limit access to ie-object with user info: ', JSON.stringify(userInfo));
 	}
 	if (!ieObject) {
 		console.error(`Trying to limit metadata on null ie object: ${ieObject}`);
@@ -117,9 +117,9 @@ export const limitAccessToObjectDetails = (
 	const accessibleLicenses = uniq(intersection(ieObjectLicenses, userAccessibleLicenses));
 
 	if (process.env.IE_OBJECT_LOG_ACCESS_CHECKS === 'true') {
-		console.log('userAccessibleLicenses: ', JSON.stringify(userAccessibleLicenses));
-		console.log('ieObjectLicenses: ', JSON.stringify(ieObjectLicenses));
-		console.log('accessibleLicenses: ', JSON.stringify(accessibleLicenses));
+		console.info('userAccessibleLicenses: ', JSON.stringify(userAccessibleLicenses));
+		console.info('ieObjectLicenses: ', JSON.stringify(ieObjectLicenses));
+		console.info('accessibleLicenses: ', JSON.stringify(accessibleLicenses));
 	}
 
 	// Step 2 - Determine ieObject limited props

--- a/src/modules/ie-objects/ie-objects.types.ts
+++ b/src/modules/ie-objects/ie-objects.types.ts
@@ -66,8 +66,10 @@ export interface IeObjectFile {
 	duration: string | number | null;
 	edmIsNextInSequence: string;
 	createdAt: string;
-	startTime?: number | null;
-	endTime?: number | null;
+	mediaFragment: {
+		startTime: number;
+		endTime: number;
+	} | null;
 }
 
 export interface IeObjectPages {
@@ -83,7 +85,6 @@ export interface IeObjectPage {
 export interface IeObjectRepresentation {
 	id: string;
 	schemaName: string;
-	isMediaFragmentOf: string;
 	schemaInLanguage: string;
 	schemaStartTime: string;
 	schemaEndTime: string;
@@ -91,15 +92,16 @@ export interface IeObjectRepresentation {
 	schemaTranscriptUrl?: string | null;
 	edmIsNextInSequence: string;
 	updatedAt: string;
+	isMediaFragmentOf: string;
 	files: IeObjectFile[];
 }
 
 /**
  * This info now lives in another place and no longer resides under is_part_of
  * alternatief → table: graph.schema_alternate_name, column: schema_alternate_name
- * serienummer  → table: graph.collection, column: schema_season_number
+ * serienummer → table: graph.collection, column: schema_season_number
  * seizoennummer → table: graph.collection, column: schema_season_number
- * registratie →  not available for now
+ * registratie → not available for now
  * stuk → not available for now
  */
 export enum IsPartOfKey {

--- a/src/modules/ie-objects/services/ie-objects.service.mocks.ts
+++ b/src/modules/ie-objects/services/ie-objects.service.mocks.ts
@@ -120,13 +120,13 @@ export const representationMp3: IeObjectRepresentation = {
 	id: 'https://data.hetarchief.be/id/entity/41ed99a7cab4918da5536322c05a9162',
 	schemaName:
 		"Lageresolutiekopie (mp3): 'Interview met leerlingen van de Europaklassen (week 69)  4-10 februari 1996\n\tschool Anderlecht' (mg7fr16t33)",
-	isMediaFragmentOf: null,
 	schemaInLanguage: null,
 	schemaStartTime: null,
 	schemaEndTime: null,
 	schemaTranscriptUrl: null,
 	edmIsNextInSequence: null,
 	updatedAt: '2025-06-23T07:10:44.031597+00:00',
+	isMediaFragmentOf: null,
 	files: [
 		{
 			id: 'https://data.hetarchief.be/id/entity/4236d6a49512a8787d8ff1425dace297',
@@ -137,6 +137,7 @@ export const representationMp3: IeObjectRepresentation = {
 			duration: 5667.08,
 			edmIsNextInSequence: null,
 			createdAt: '2025-06-23T07:10:47.175853+00:00',
+			mediaFragment: null,
 		},
 		{
 			id: 'https://data.hetarchief.be/id/entity/a57f867f107a4734b183198390974205',
@@ -147,6 +148,7 @@ export const representationMp3: IeObjectRepresentation = {
 			duration: null,
 			edmIsNextInSequence: null,
 			createdAt: '2025-06-23T07:26:28.249917+00:00',
+			mediaFragment: null,
 		},
 	],
 };
@@ -154,13 +156,13 @@ const representationMp4: IeObjectRepresentation = {
 	id: 'https://data.hetarchief.be/id/entity/b510a045a192e5cfda4738dd129af99d',
 	schemaName:
 		"Lageresolutiekopie (mp4): 'Interview met leerlingen van de Europaklassen (week 69)  4-10 februari 1996\n\tschool Anderlecht' (mg7fr16t33)",
-	isMediaFragmentOf: null,
 	schemaInLanguage: null,
 	schemaStartTime: null,
 	schemaEndTime: null,
 	schemaTranscriptUrl: null,
 	edmIsNextInSequence: null,
 	updatedAt: '2025-06-23T07:28:33.301476+00:00',
+	isMediaFragmentOf: null,
 	files: [
 		{
 			id: 'https://data.hetarchief.be/id/entity/e5cad209c5bcddff3e884804825b6e7b',
@@ -173,6 +175,7 @@ const representationMp4: IeObjectRepresentation = {
 			duration: 5667.08,
 			edmIsNextInSequence: null,
 			createdAt: '2025-06-23T07:36:16.188475+00:00',
+			mediaFragment: null,
 		},
 		{
 			id: 'https://data.hetarchief.be/id/entity/a57f867f107a4734b183198390974205',
@@ -183,6 +186,7 @@ const representationMp4: IeObjectRepresentation = {
 			duration: null,
 			edmIsNextInSequence: null,
 			createdAt: '2025-06-23T07:26:28.249917+00:00',
+			mediaFragment: null,
 		},
 	],
 };
@@ -190,13 +194,13 @@ const representationMa4: IeObjectRepresentation = {
 	id: 'https://data.hetarchief.be/id/entity/dc83542dfbfa88127b3107600349d045',
 	schemaName:
 		"Lageresolutiekopie (m4a): 'Interview met leerlingen van de Europaklassen (week 69)  4-10 februari 1996\n\tschool Anderlecht' (mg7fr16t33)",
-	isMediaFragmentOf: null,
 	schemaInLanguage: null,
 	schemaStartTime: null,
 	schemaEndTime: null,
 	schemaTranscriptUrl: null,
 	edmIsNextInSequence: null,
 	updatedAt: '2025-06-23T07:34:47.956169+00:00',
+	isMediaFragmentOf: null,
 	files: [
 		{
 			id: 'https://data.hetarchief.be/id/entity/53db6fbda94c45b7dd0af42fa91e19d6',
@@ -207,6 +211,7 @@ const representationMa4: IeObjectRepresentation = {
 			duration: 5667.08,
 			edmIsNextInSequence: null,
 			createdAt: '2025-06-23T07:13:32.147052+00:00',
+			mediaFragment: null,
 		},
 		{
 			id: 'https://data.hetarchief.be/id/entity/a57f867f107a4734b183198390974205',
@@ -217,6 +222,7 @@ const representationMa4: IeObjectRepresentation = {
 			duration: null,
 			edmIsNextInSequence: null,
 			createdAt: '2025-06-23T07:26:28.249917+00:00',
+			mediaFragment: null,
 		},
 	],
 };
@@ -224,13 +230,13 @@ export const representationsNewspaper: IeObjectRepresentation[] = [
 	{
 		id: 'https://data.hetarchief.be/id/entity/26420d7bcb57fa9bad812876bb2fa44c/b565a828249953ec74bae4d396849891',
 		schemaName: "IIIF kopie (jp2): 'La Libre Belgique' (26420d7bcb57fa9bad812876bb2fa44c)",
-		isMediaFragmentOf: null,
 		schemaInLanguage: null,
 		schemaStartTime: null,
 		schemaEndTime: null,
 		schemaTranscriptUrl: null,
 		edmIsNextInSequence: null,
 		updatedAt: '2025-06-23T07:06:11.271076+00:00',
+		isMediaFragmentOf: null,
 		files: [
 			{
 				id: 'https://data.hetarchief.be/id/entity/26420d7bcb57fa9bad812876bb2fa44c/2f1201c076bcede9f55f79b572a3bc03',
@@ -241,19 +247,20 @@ export const representationsNewspaper: IeObjectRepresentation[] = [
 				duration: null,
 				edmIsNextInSequence: null,
 				createdAt: '2025-06-23T07:06:11.424502+00:00',
+				mediaFragment: null,
 			},
 		],
 	},
 	{
 		id: 'https://data.hetarchief.be/id/entity/c00286fbc2f1209659e70cf508620569',
 		schemaName: "Lageresolutiekopie (jpg): 'La Libre Belgique' (8p5v698x44)",
-		isMediaFragmentOf: null,
 		schemaInLanguage: null,
 		schemaStartTime: null,
 		schemaEndTime: null,
 		schemaTranscriptUrl: null,
 		edmIsNextInSequence: null,
 		updatedAt: '2025-06-23T07:30:24.376609+00:00',
+		isMediaFragmentOf: null,
 		files: [
 			{
 				id: 'https://data.hetarchief.be/id/entity/5787a7741ad5743244a79f5a3e4f876d',
@@ -266,6 +273,7 @@ export const representationsNewspaper: IeObjectRepresentation[] = [
 				duration: null,
 				edmIsNextInSequence: null,
 				createdAt: '2025-06-23T07:14:05.614178+00:00',
+				mediaFragment: null,
 			},
 		],
 	},
@@ -273,7 +281,6 @@ export const representationsNewspaper: IeObjectRepresentation[] = [
 		id: 'https://data.hetarchief.be/id/entity/faf96630b357f09db896c8d1a67bc865',
 		schemaName:
 			"Digitale representatie (alto): '8p5v698x44_19181112_0001_alto.xml' (26420d7bcb57fa9bad812876bb2fa44c)",
-		isMediaFragmentOf: null,
 		schemaInLanguage: null,
 		schemaStartTime: null,
 		schemaEndTime: null,
@@ -283,6 +290,7 @@ export const representationsNewspaper: IeObjectRepresentation[] = [
 			'http://swarmget.do.viaa.be/alto/a22094fa0a494a4b932a33d233ecad588da595dec3144bfbb9d1104102ef8d1b.xml.json?domain=s3.viaa.be',
 		edmIsNextInSequence: null,
 		updatedAt: '2025-06-23T07:39:13.913201+00:00',
+		isMediaFragmentOf: null,
 		files: [
 			{
 				id: 'https://data.hetarchief.be/id/entity/88a85bbb95b56ed0f5ee026d180bb15c',
@@ -293,6 +301,7 @@ export const representationsNewspaper: IeObjectRepresentation[] = [
 				duration: null,
 				edmIsNextInSequence: null,
 				createdAt: '2025-06-23T07:21:49.762545+00:00',
+				mediaFragment: null,
 			},
 		],
 	},

--- a/src/modules/ie-objects/services/ie-objects.service.spec.ts
+++ b/src/modules/ie-objects/services/ie-objects.service.spec.ts
@@ -699,4 +699,98 @@ describe('ieObjectsService', () => {
 			expect(result).toHaveLength(3);
 		});
 	});
+
+	describe('adaptRepresentationsPaged', () => {
+		const baseRepresentation = {
+			schema_in_language: null,
+			schema_start_time: null,
+			schema_end_time: null,
+			schemaTranscriptUrls: null,
+			edm_is_next_in_sequence: null,
+			updated_at: '2025-01-01T00:00:00Z',
+			includes: [],
+		};
+
+		it('filters out cut-fragment representations when a main representation (is_media_fragment_of: null) exists', async () => {
+			const adaptRepresentationsSpy = vi
+				.spyOn(ieObjectsService, 'adaptRepresentations')
+				.mockResolvedValue([]);
+
+			const mainRepresentation = {
+				...baseRepresentation,
+				id: 'main-rep-id',
+				schema_name: 'main-rep',
+				is_media_fragment_of: null,
+			};
+			const cutFragmentRepresentation = {
+				...baseRepresentation,
+				id: 'cut-fragment-rep-id',
+				schema_name: 'cut-fragment-rep',
+				is_media_fragment_of: 'parent-id',
+			};
+
+			const ieObjectSelf = [
+				{ isRepresentedBy: [mainRepresentation, cutFragmentRepresentation] },
+			];
+
+			await ieObjectsService.adaptRepresentationsPaged(
+				ieObjectSelf as any,
+				null,
+				false,
+				false,
+				'referer',
+				'127.0.0.1'
+			);
+
+			// Only the main representation should be passed through; cut fragment must be removed
+			expect(adaptRepresentationsSpy).toHaveBeenCalledWith(
+				[mainRepresentation],
+				false,
+				false,
+				'referer',
+				'127.0.0.1'
+			);
+		});
+
+		it('keeps all representations when no main representation exists (cut-fragment object)', async () => {
+			const adaptRepresentationsSpy = vi
+				.spyOn(ieObjectsService, 'adaptRepresentations')
+				.mockResolvedValue([]);
+
+			const cutFragmentRepresentation1 = {
+				...baseRepresentation,
+				id: 'cut-fragment-rep-1',
+				schema_name: 'cut-fragment-rep-1',
+				is_media_fragment_of: 'parent-id',
+			};
+			const cutFragmentRepresentation2 = {
+				...baseRepresentation,
+				id: 'cut-fragment-rep-2',
+				schema_name: 'cut-fragment-rep-2',
+				is_media_fragment_of: 'parent-id',
+			};
+
+			const ieObjectSelf = [
+				{ isRepresentedBy: [cutFragmentRepresentation1, cutFragmentRepresentation2] },
+			];
+
+			await ieObjectsService.adaptRepresentationsPaged(
+				ieObjectSelf as any,
+				null,
+				false,
+				false,
+				'referer',
+				'127.0.0.1'
+			);
+
+			// Both cut-fragment representations must be kept — no filtering applied
+			expect(adaptRepresentationsSpy).toHaveBeenCalledWith(
+				[cutFragmentRepresentation1, cutFragmentRepresentation2],
+				false,
+				false,
+				'referer',
+				'127.0.0.1'
+			);
+		});
+	});
 });

--- a/src/modules/ie-objects/services/ie-objects.service.ts
+++ b/src/modules/ie-objects/services/ie-objects.service.ts
@@ -4,13 +4,7 @@ import { retry } from 'async';
 
 import { DataService, PlayerTicketService } from '@meemoo/admin-core-api';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import {
-	Inject,
-	Injectable,
-	InternalServerErrorException,
-	Logger,
-	NotFoundException,
-} from '@nestjs/common';
+import { Inject, Injectable, InternalServerErrorException, Logger, NotFoundException, } from '@nestjs/common';
 
 import { ConfigService } from '@nestjs/config';
 import { type IPagination, Pagination } from '@studiohyperdrive/pagination';
@@ -42,10 +36,10 @@ import {
 	type IeObjectPages,
 	type IeObjectRepresentation,
 	type IeObjectSector,
-	IeObjectType,
 	type IeObjectsSitemap,
 	type IeObjectsVisitorSpaceInfo,
 	type IeObjectsWithAggregations,
+	IeObjectType,
 	type IsPartOfKey,
 	type Mention,
 	type RelatedIeObject,
@@ -97,25 +91,19 @@ import {
 	MAX_COUNT_SEARCH_RESULTS,
 } from '~modules/ie-objects/elasticsearch/elasticsearch.consts';
 import { AND } from '~modules/ie-objects/elasticsearch/queryBuilder.helpers';
+import { convertStringToSearchTerms, type SearchTermParseResult, } from '~modules/ie-objects/helpers/convert-string-to-search-terms';
+import { AUTOCOMPLETE_FIELD_TO_ES_FIELD_NAME, IE_OBJECT_AV_TYPES, } from '~modules/ie-objects/ie-objects.conts';
 import {
-	type SearchTermParseResult,
-	convertStringToSearchTerms,
-} from '~modules/ie-objects/helpers/convert-string-to-search-terms';
-import {
-	AUTOCOMPLETE_FIELD_TO_ES_FIELD_NAME,
-	IE_OBJECT_AV_TYPES,
-} from '~modules/ie-objects/ie-objects.conts';
-import {
-	CACHE_KEY_PREFIX_IE_OBJECTS_SEARCH,
 	CACHE_KEY_PREFIX_IE_OBJECT_DETAIL,
 	CACHE_KEY_PREFIX_IE_OBJECT_PID_TO_ID,
 	CACHE_KEY_PREFIX_IE_OBJECT_THUMBNAIL,
+	CACHE_KEY_PREFIX_IE_OBJECTS_SEARCH,
 } from '~modules/ie-objects/services/ie-objects.service.consts';
 import {
-	DbFile,
+	type DbFile,
 	type DbIeObjectWithMentions,
 	type DbIeObjectWithRepresentations,
-	DbIncludeFile,
+	type DbIncludeFile,
 	type DbIncludeFiles,
 	type DbRepresentation,
 } from '~modules/ie-objects/services/ie-objects.service.types';
@@ -1055,14 +1043,13 @@ export class IeObjectsService {
 
 		// Check if video is a main video or a cut fragment of a main video
 		// https://meemoo.atlassian.net/browse/ARC-3690?focusedCommentId=87432
-		console.log('ieObjects: ', JSON.stringify(ieObjects));
 		const hasMainFragment = ieObjects.find((ieObject) =>
 			ieObject.isRepresentedBy?.find(
 				(representation) => representation.is_media_fragment_of === null
 			)
 		);
 		if (hasMainFragment) {
-			// Show the ma	in fragment and the DVD chapters
+			// Show the main fragment and the DVD chapters
 			// Delete the cut fragments
 			for (const ieObject of ieObjects) {
 				ieObject.isRepresentedBy = compact(
@@ -1218,10 +1205,13 @@ export class IeObjectsService {
 
 	/**
 	 * Checks if first hasMediaFragment has valid start- and end time
-	 * and returns simplified format
+	 * and returns a simplified format
+	 * schema_start_time and schema_end_time are in the format: HH:mm:ss.µµµ
+	 * and this function converts that to integer seconds
 	 * @param file
 	 */
 	private adaptMediaFragment(file: DbFile): { startTime: number; endTime: number } | null {
+		// format: HH:mm:ss.µµµ
 		const startTimeFormatted: string | undefined | null =
 			file.hasMediaFragment?.[0]?.schema_start_time;
 		const endTimeFormatted: string | undefined | null = file.hasMediaFragment?.[0]?.schema_end_time;
@@ -1229,6 +1219,7 @@ export class IeObjectsService {
 		if (isNil(startTimeFormatted) || isNil(endTimeFormatted)) {
 			return null;
 		}
+		// convert to seconds (integer)
 		const startTime = formattedDurationToSeconds(startTimeFormatted);
 		const endTime = formattedDurationToSeconds(endTimeFormatted);
 
@@ -1755,7 +1746,7 @@ export class IeObjectsService {
 	public getRepresentationAndFileInIeObject(
 		ieObject: Partial<IeObject>,
 		fileId: string
-	): [IeObjectFile, IeObjectRepresentation] {
+	): [IeObjectFile | null, IeObjectRepresentation | null] {
 		// Check if requested file has time codes to cut the fragment out of a video
 		// https://meemoo.atlassian.net/browse/ARC-3690
 		let requestedFile: IeObjectFile | null = null;

--- a/src/modules/ie-objects/services/ie-objects.service.ts
+++ b/src/modules/ie-objects/services/ie-objects.service.ts
@@ -18,7 +18,7 @@ import { mapLimit } from 'blend-promise-utils';
 import type { Cache } from 'cache-manager';
 import got, { type Got } from 'got';
 
-import { compact, find, isArray, isEmpty, isNil, kebabCase, omitBy, uniq } from 'lodash';
+import { compact, find, isArray, isEmpty, isNil, isNumber, kebabCase, omitBy, uniq } from 'lodash';
 
 import type { Configuration } from '~config';
 
@@ -112,9 +112,11 @@ import {
 	CACHE_KEY_PREFIX_IE_OBJECT_THUMBNAIL,
 } from '~modules/ie-objects/services/ie-objects.service.consts';
 import {
-	type DbFile,
+	DbFile,
 	type DbIeObjectWithMentions,
 	type DbIeObjectWithRepresentations,
+	DbIncludeFile,
+	type DbIncludeFiles,
 	type DbRepresentation,
 } from '~modules/ie-objects/services/ie-objects.service.types';
 import { OrganisationPreference } from '~modules/organisations/organisations.types';
@@ -1038,7 +1040,7 @@ export class IeObjectsService {
 		ip: string
 	): Promise<IeObjectPages | null> {
 		const ieObjectParts = hasPartResponse || [];
-		const ieObjects = (
+		const ieObjects: DbIeObjectWithRepresentations[] = (
 			compact([
 				...(isArray(ieObjectSelf) ? ieObjectSelf : [ieObjectSelf]),
 				...ieObjectParts,
@@ -1050,6 +1052,33 @@ export class IeObjectsService {
 		}
 
 		const allMentions: Mention[] = [];
+
+		// Check if video is a main video or a cut fragment of a main video
+		// https://meemoo.atlassian.net/browse/ARC-3690?focusedCommentId=87432
+		console.log('ieObjects: ', JSON.stringify(ieObjects));
+		const hasMainFragment = ieObjects.find((ieObject) =>
+			ieObject.isRepresentedBy?.find(
+				(representation) => representation.is_media_fragment_of === null
+			)
+		);
+		if (hasMainFragment) {
+			// Show the ma	in fragment and the DVD chapters
+			// Delete the cut fragments
+			for (const ieObject of ieObjects) {
+				ieObject.isRepresentedBy = compact(
+					(ieObject.isRepresentedBy || [])?.map(
+						(representation: DbIeObjectWithRepresentations['isRepresentedBy'][0]) => {
+							if (representation.is_media_fragment_of) {
+								return null;
+							}
+							return representation;
+						}
+					)
+				) as DbIeObjectWithRepresentations['isRepresentedBy'];
+			}
+		} else {
+			// This is probably a cut fragment => no need to remove any cut fragments
+		}
 
 		/* istanbul ignore next */
 		// Standardize the isRepresentedBy and the hasPart.isRepresentedBy parts of the query to a list of pages with each their file representations
@@ -1108,6 +1137,7 @@ export class IeObjectsService {
 					if (!representation) {
 						return null;
 					}
+
 					const transcriptInfo = representation.schemaTranscriptUrls?.[0];
 					const schemaTranscript = transcriptInfo?.schema_transcript;
 					const schemaTranscriptUrl = transcriptInfo?.schema_transcript_url || null;
@@ -1115,7 +1145,6 @@ export class IeObjectsService {
 					return {
 						id: representation.id,
 						schemaName: representation.schema_name,
-						isMediaFragmentOf: representation.is_media_fragment_of,
 						schemaInLanguage: representation.schema_in_language,
 						schemaStartTime: representation.schema_start_time,
 						schemaEndTime: representation.schema_end_time,
@@ -1123,6 +1152,7 @@ export class IeObjectsService {
 						schemaTranscriptUrl,
 						edmIsNextInSequence: representation.edm_is_next_in_sequence,
 						updatedAt: representation.updated_at,
+						isMediaFragmentOf: representation.is_media_fragment_of,
 						files: await this.adaptFiles(
 							representation.includes,
 							resolveThumbnailUrl,
@@ -1139,50 +1169,76 @@ export class IeObjectsService {
 	}
 
 	public async adaptFiles(
-		dbFiles: DbFile,
+		dbIncludeFiles: DbIncludeFiles,
 		resolveThumbnailUrl: boolean,
 		isPublicDomain: boolean,
 		referer: string,
 		ip: string
 	): Promise<IeObjectFile[]> {
-		if (!dbFiles || isEmpty(dbFiles)) {
+		if (!dbIncludeFiles || isEmpty(dbIncludeFiles)) {
 			return [];
 		}
 
 		/* istanbul ignore next */
 		return compact(
-			await mapLimit(dbFiles, 20, async (includeFile): Promise<IeObjectFile> => {
-				const file = includeFile.file;
-				if (!file) {
-					return null;
-				}
+			await mapLimit(
+				dbIncludeFiles,
+				20,
+				async (includeFile: DbIncludeFile): Promise<IeObjectFile> => {
+					const file: DbFile = includeFile.file;
+					if (!file) {
+						return null;
+					}
 
-				let thumbnailUrl: string | undefined = undefined;
-				if (resolveThumbnailUrl) {
-					thumbnailUrl = await this.getThumbnailUrlWithToken(
-						file.schema_thumbnail_url,
-						referer,
-						ip,
-						isPublicDomain
-					);
-				}
+					let thumbnailUrl: string | undefined = undefined;
+					if (resolveThumbnailUrl) {
+						thumbnailUrl = await this.getThumbnailUrlWithToken(
+							file.schema_thumbnail_url,
+							referer,
+							ip,
+							isPublicDomain
+						);
+					}
 
-				const startTime = file.hasMediaFragment?.[0]?.schema_start_time;
-				const endTime = file.hasMediaFragment?.[0]?.schema_end_time;
-				return {
-					id: file.id,
-					name: file.schema_name,
-					mimeType: file.ebucore_has_mime_type,
-					storedAt: file.premis_stored_at,
-					thumbnailUrl,
-					duration: file.schema_duration,
-					edmIsNextInSequence: file.edm_is_next_in_sequence,
-					createdAt: file.created_at,
-					startTime: startTime ? formattedDurationToSeconds(startTime) : null,
-					endTime: endTime ? formattedDurationToSeconds(endTime) : null,
-				};
-			})
+					return {
+						id: file.id,
+						name: file.schema_name,
+						mimeType: file.ebucore_has_mime_type,
+						storedAt: file.premis_stored_at,
+						thumbnailUrl,
+						duration: file.schema_duration,
+						edmIsNextInSequence: file.edm_is_next_in_sequence,
+						createdAt: file.created_at,
+						mediaFragment: this.adaptMediaFragment(file),
+					};
+				}
+			)
 		);
+	}
+
+	/**
+	 * Checks if first hasMediaFragment has valid start- and end time
+	 * and returns simplified format
+	 * @param file
+	 */
+	private adaptMediaFragment(file: DbFile): { startTime: number; endTime: number } | null {
+		const startTimeFormatted: string | undefined | null =
+			file.hasMediaFragment?.[0]?.schema_start_time;
+		const endTimeFormatted: string | undefined | null = file.hasMediaFragment?.[0]?.schema_end_time;
+
+		if (isNil(startTimeFormatted) || isNil(endTimeFormatted)) {
+			return null;
+		}
+		const startTime = formattedDurationToSeconds(startTimeFormatted);
+		const endTime = formattedDurationToSeconds(endTimeFormatted);
+
+		if (!isNumber(startTime) || !isNumber(endTime)) {
+			return null;
+		}
+		return {
+			startTime,
+			endTime,
+		};
 	}
 
 	private adaptForSitemap(
@@ -1696,20 +1752,25 @@ export class IeObjectsService {
 		}
 	}
 
-	public getFileInIeObject(ieObject: Partial<IeObject>, fileId: string): IeObjectFile {
+	public getRepresentationAndFileInIeObject(
+		ieObject: Partial<IeObject>,
+		fileId: string
+	): [IeObjectFile, IeObjectRepresentation] {
 		// Check if requested file has time codes to cut the fragment out of a video
 		// https://meemoo.atlassian.net/browse/ARC-3690
 		let requestedFile: IeObjectFile | null = null;
+		let requestedRepresentation: IeObjectRepresentation | null = null;
 		ieObject.pages?.find((page) => {
 			return page.representations?.find((representation) => {
 				return representation?.files?.find((file) => {
 					if (file.id === fileId) {
 						requestedFile = file;
+						requestedRepresentation = representation;
 						return true; // Stop searching
 					}
 				});
 			});
 		});
-		return requestedFile;
+		return [requestedFile, requestedRepresentation];
 	}
 }

--- a/src/modules/ie-objects/services/ie-objects.service.types.ts
+++ b/src/modules/ie-objects/services/ie-objects.service.types.ts
@@ -8,4 +8,6 @@ export type DbIeObjectWithMentions = GetIeObjectDetailQuery['getHasPart'][0];
 
 export type DbRepresentation = DbIeObjectWithRepresentations['isRepresentedBy'][0];
 
-export type DbFile = DbRepresentation['includes'];
+export type DbIncludeFiles = DbRepresentation['includes'];
+export type DbIncludeFile = DbRepresentation['includes'][0];
+export type DbFile = DbIncludeFile['file'];

--- a/src/modules/material-request-messages/controllers/material-request-messages.controller.ts
+++ b/src/modules/material-request-messages/controllers/material-request-messages.controller.ts
@@ -140,7 +140,7 @@ export class MaterialRequestMessagesController {
 				page,
 				size,
 			});
-			console.log(error);
+			console.error(error);
 			error.innerException = null;
 			throw error;
 		}
@@ -167,7 +167,7 @@ export class MaterialRequestMessagesController {
 				materialRequestId,
 				userId: user?.getId(),
 			});
-			console.log(error);
+			console.error(error);
 			error.innerException = null;
 			throw error;
 		}
@@ -252,7 +252,7 @@ export class MaterialRequestMessagesController {
 				materialRequestId,
 				userId: user?.getId(),
 			});
-			console.log(error);
+			console.error(error);
 			error.innerException = null;
 			throw error;
 		}
@@ -298,7 +298,7 @@ export class MaterialRequestMessagesController {
 				userId: user?.getId(),
 				extraConditions: body.extraConditions,
 			});
-			console.log(error);
+			console.error(error);
 			error.innerException = null;
 			throw error;
 		}
@@ -438,7 +438,7 @@ export class MaterialRequestMessagesController {
 				materialRequestId,
 				userId: user?.getId(),
 			});
-			console.log(error);
+			console.error(error);
 			error.innerException = null;
 			throw error;
 		}
@@ -505,7 +505,7 @@ export class MaterialRequestMessagesController {
 				orderProp: queryDto.orderProp,
 				orderDirection: queryDto.orderDirection,
 			});
-			console.log(error);
+			console.error(error);
 			error.innerException = null;
 			throw error;
 		}
@@ -570,7 +570,7 @@ export class MaterialRequestMessagesController {
 						userId: user?.getId(),
 					}
 				);
-				console.log(error);
+				console.error(error);
 				throw error;
 			}
 		}
@@ -611,7 +611,7 @@ export class MaterialRequestMessagesController {
 				attachmentId,
 				userId: user?.getId(),
 			});
-			console.log(error);
+			console.error(error);
 			error.innerException = null;
 			throw error;
 		}
@@ -680,7 +680,7 @@ export class MaterialRequestMessagesController {
 			const error = new CustomError('Failed to generate material request PDF', err, {
 				materialRequestId,
 			});
-			console.log(error);
+			console.error(error);
 			error.innerException = null;
 			throw error;
 		}
@@ -712,7 +712,7 @@ export class MaterialRequestMessagesController {
 			const error = new CustomError('Failed to generate complete summary PDF', err, {
 				materialRequestId,
 			});
-			console.log(error);
+			console.error(error);
 			error.innerException = null;
 			throw error;
 		}

--- a/src/modules/material-requests/controllers/material-requests-scheduling.controller.ts
+++ b/src/modules/material-requests/controllers/material-requests-scheduling.controller.ts
@@ -26,7 +26,7 @@ export class MaterialRequestsSchedulingController {
 				.checkAllReadyForArchivation()
 				.then(noop)
 				.catch((err) => {
-					console.log(
+					console.error(
 						new CustomError(
 							'Error during checkMaterialRequestsForArchivation => checkAllReadyForArchivation cron',
 							err

--- a/src/modules/material-requests/services/material-requests.service.ts
+++ b/src/modules/material-requests/services/material-requests.service.ts
@@ -1,30 +1,9 @@
 import { parse } from 'node:path';
-import {
-	AssetsService,
-	DataService,
-	Locale,
-	StillsObjectType,
-	VideoStillsService,
-} from '@meemoo/admin-core-api';
-import {
-	BadRequestException,
-	Injectable,
-	InternalServerErrorException,
-	NotFoundException,
-} from '@nestjs/common';
+import { AssetsService, DataService, Locale, StillsObjectType, VideoStillsService, } from '@meemoo/admin-core-api';
+import { BadRequestException, Injectable, InternalServerErrorException, NotFoundException, } from '@nestjs/common';
 import { type IPagination, Pagination } from '@studiohyperdrive/pagination';
 import { mapLimit } from 'blend-promise-utils';
-import {
-	compact,
-	groupBy,
-	intersection,
-	isArray,
-	isEmpty,
-	isNil,
-	kebabCase,
-	noop,
-	set,
-} from 'lodash';
+import { compact, groupBy, intersection, isArray, isEmpty, isNil, kebabCase, noop, set, } from 'lodash';
 
 import {
 	CreateMaterialRequestDto,

--- a/src/modules/mediahaven-jobs-watcher/controllers/mediahaven-jobs-watcher.controller.ts
+++ b/src/modules/mediahaven-jobs-watcher/controllers/mediahaven-jobs-watcher.controller.ts
@@ -2,10 +2,7 @@ import { CustomError } from '@meemoo/admin-core-api/dist/src/modules/shared/help
 import { Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { noop } from 'lodash';
-import {
-	CreateMamJobRequestBody,
-	MediahavenJobInfo,
-} from '~modules/mediahaven-jobs-watcher/mediahaven-jobs-watcher.types';
+import { CreateMamJobRequestBody, MediahavenJobInfo, } from '~modules/mediahaven-jobs-watcher/mediahaven-jobs-watcher.types';
 import { MediahavenJobsWatcherService } from '~modules/mediahaven-jobs-watcher/services/mediahaven-jobs-watcher.service';
 import { ApiKeyGuard } from '~shared/guards/api-key.guard';
 import { LocalhostGuard } from '~shared/guards/localhost.guard';
@@ -30,7 +27,7 @@ export class MediahavenJobsWatcherController {
 				.checkUnresolvedJobs()
 				.then(noop)
 				.catch((err) => {
-					console.log(
+					console.error(
 						new CustomError(
 							'Error during checkMediahavenJobsStatuses => checkUnresolvedJobs cron',
 							err
@@ -41,7 +38,7 @@ export class MediahavenJobsWatcherController {
 				.checkExpiredDownloads()
 				.then(noop)
 				.catch((err) => {
-					console.log(
+					console.error(
 						new CustomError(
 							'Error during checkMediahavenJobsStatuses => checkExpiredDownloads cron',
 							err
@@ -69,7 +66,7 @@ export class MediahavenJobsWatcherController {
 				.checkAlmostExpiredDownloads()
 				.then(noop)
 				.catch((err) => {
-					console.log(
+					console.error(
 						new CustomError(
 							'Error during checkMediahavenJobsStatuses => checkAlmostExpiredDownloads cron',
 							err

--- a/src/modules/mediahaven-jobs-watcher/services/mediahaven-jobs-watcher.service.ts
+++ b/src/modules/mediahaven-jobs-watcher/services/mediahaven-jobs-watcher.service.ts
@@ -2,7 +2,7 @@ import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { DataService, MediahavenService } from '@meemoo/admin-core-api';
 import { CustomError } from '@meemoo/admin-core-api/dist/src/modules/shared/helpers/error';
-import { Inject, Injectable, forwardRef } from '@nestjs/common';
+import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { AvoUserCommonUser } from '@viaa/avo2-types';
 import { mapLimit } from 'blend-promise-utils';
@@ -40,8 +40,8 @@ import {
 	MamAccessToken,
 	MamExportQuality,
 	MamJobStatus,
-	MediaHavenRecord,
 	MediahavenJobInfo,
+	MediaHavenRecord,
 	S3ExportLocationToken,
 } from '~modules/mediahaven-jobs-watcher/mediahaven-jobs-watcher.types';
 import { NotificationType } from '~modules/notifications/types';
@@ -294,7 +294,7 @@ export class MediahavenJobsWatcherService {
 					);
 				}
 			}
-			console.log('Mediahaven jobs check report', reportItems);
+			console.info('Mediahaven jobs check report', reportItems);
 		} catch (err) {
 			throw new CustomError('Error checking mediahaven jobs', err);
 		}
@@ -535,7 +535,7 @@ export class MediahavenJobsWatcherService {
 				url,
 				body,
 			});
-			console.log(error);
+			console.error(error);
 			error.innerException = null;
 			throw error;
 		}


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-3690

removes cut fragments from the representation list of a main video
for the cut video ie-object nothing has to change



main video with cut fragments:
<img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/4daafd62-2606-449d-964d-a93ee6f51c7c" />

cut video:
<img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/0d96791f-e41a-48f6-8bef-50b8b6e76f72" />

dvd with chapters:
<img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/711363f4-ba1f-44be-96c2-514f995c7b51" />

regular main video: (still works)
<img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/25cf607b-9f22-4b84-9a3b-76c4b19aeae5" />

newspaper: (still works)
<img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/0fb45b93-ecfb-478c-955c-9c6ee4aabcfc" />
