### PR TITLE
feat(ARC-3756): add checks to avoid ieObjectId null in queries

### DIFF
--- a/src/modules/folders/controllers/folders.controller.spec.ts
+++ b/src/modules/folders/controllers/folders.controller.spec.ts
@@ -2,7 +2,7 @@ import { Test, type TestingModule } from '@nestjs/testing';
 import type { IPagination } from '@studiohyperdrive/pagination';
 import { AvoAuthIdpType, PermissionName } from '@viaa/avo2-types';
 import type { Request } from 'express';
-import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { type MockInstance, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { FoldersService } from '../services/folders.service';
 
@@ -119,7 +119,7 @@ const mockIeObjectsService: Partial<Record<keyof IeObjectsService, MockInstance>
 	findByIeObjectId: vi.fn(),
 	getVisitorSpaceAccessInfoFromUser: vi.fn(),
 	limitObjectInFolder: vi.fn((folderObjectItem: Partial<IeObject>) => folderObjectItem),
-	getObjectIdBySchemaIdentifierCached: vi.fn().mockResolvedValue('mock-ie-object-id'),
+	getIeObjectIdFromObjectSchemaIdentifier: vi.fn(),
 };
 
 const mockVisitsService: Partial<Record<keyof VisitsService, MockInstance>> = {
@@ -282,7 +282,9 @@ describe('FoldersController', () => {
 			mockFoldersService.findFolderById.mockResolvedValueOnce(mockFoldersResponse.items[0]);
 			mockFoldersService.findFolderById.mockResolvedValueOnce(mockFoldersResponse.items[0]);
 			mockFoldersService.findObjectInFolderById.mockResolvedValue(mockFoldersResponse.items[0]);
-			mockIeObjectsService.getObjectIdBySchemaIdentifierCached.mockResolvedValue(mockIeObject1.iri);
+			mockIeObjectsService.getIeObjectIdFromObjectSchemaIdentifier.mockResolvedValue(
+				mockIeObject1.iri
+			);
 			mockIeObjectsService.findByIeObjectId.mockResolvedValue([mockIeObject1]);
 			mockEventsService.insertEvents.mockResolvedValueOnce([]);
 			const folderObject = await foldersController.addObjectToFolder(
@@ -332,7 +334,8 @@ describe('FoldersController', () => {
 				mockFoldersResponse.items[0].id,
 				mockSchemaIdentifier,
 				'127.0.0.1',
-				new SessionUserEntity(mockUser)
+				new SessionUserEntity(mockUser),
+				{ path: '', params: {} } as unknown as Request
 			);
 			expect(folderObject).toEqual({ status: 'the object has been deleted' });
 		});
@@ -345,7 +348,8 @@ describe('FoldersController', () => {
 				mockFoldersResponse.items[0].id,
 				'non-existing-object-id',
 				'127.0.0.1',
-				new SessionUserEntity(mockUser)
+				new SessionUserEntity(mockUser),
+				{ path: '', params: {} } as unknown as Request
 			);
 			expect(folderObject).toEqual({
 				status: 'no object found with that id in that folder',
@@ -366,7 +370,8 @@ describe('FoldersController', () => {
 					mockFoldersResponse.items[0].id,
 					mockSchemaIdentifier,
 					'127.0.0.1',
-					new SessionUserEntity(mockUser)
+					new SessionUserEntity(mockUser),
+					{ path: '', params: {} } as unknown as Request
 				);
 			} catch (e) {
 				error = e;
@@ -390,7 +395,8 @@ describe('FoldersController', () => {
 				mockFoldersResponse.items[0].id,
 				mockSchemaIdentifier,
 				mockFoldersResponse.items[1].id,
-				new SessionUserEntity(mockUser)
+				new SessionUserEntity(mockUser),
+				{ path: '', params: {} } as unknown as Request
 			);
 			expect(folderObject).toEqual(mockFolderObjectsResponse.items[0]);
 		});
@@ -416,7 +422,8 @@ describe('FoldersController', () => {
 					mockFoldersResponse.items[0].id,
 					mockSchemaIdentifier,
 					mockFoldersResponse.items[1].id,
-					new SessionUserEntity(mockUser)
+					new SessionUserEntity(mockUser),
+					{ path: '', params: {} } as unknown as Request
 				);
 			} catch (e) {
 				error = e;
@@ -445,7 +452,8 @@ describe('FoldersController', () => {
 					mockFoldersResponse.items[0].id,
 					mockSchemaIdentifier,
 					mockFoldersResponse.items[1].id,
-					new SessionUserEntity(mockUser)
+					new SessionUserEntity(mockUser),
+					{ path: '', params: {} } as unknown as Request
 				);
 			} catch (e) {
 				error = e;

--- a/src/modules/folders/controllers/folders.controller.ts
+++ b/src/modules/folders/controllers/folders.controller.ts
@@ -39,7 +39,9 @@ import { type IeObject, IeObjectLicense } from '~modules/ie-objects/ie-objects.t
 import { IeObjectsService } from '~modules/ie-objects/services/ie-objects.service';
 import { SessionUserEntity } from '~modules/users/classes/session-user';
 
+import { CustomError } from '@meemoo/admin-core-api/dist/src/modules/shared/helpers/error';
 import { PermissionName } from '@viaa/avo2-types';
+import { object } from 'joi';
 import { mapDcTermsFormatToSimpleType } from '~modules/ie-objects/helpers/map-dc-terms-format-to-simple-type';
 import { UsersService } from '~modules/users/services/users.service';
 import { Ip } from '~shared/decorators/ip.decorator';
@@ -230,12 +232,10 @@ export class FoldersController {
 			throw new ForbiddenException('You can only add objects to your own folders');
 		}
 
-		const ieObjectId =
-			await this.ieObjectsService.getObjectIdBySchemaIdentifierCached(objectSchemaIdentifier);
-
-		if (!ieObjectId) {
-			throw new NotFoundException('Object not found');
-		}
+		const ieObjectId = await this.ieObjectsService.getIeObjectIdFromObjectSchemaIdentifier(
+			objectSchemaIdentifier,
+			request
+		);
 
 		const folderObject = await this.foldersService.addObjectToFolder(
 			folderId,
@@ -278,14 +278,19 @@ export class FoldersController {
 		@Ip() ip: string,
 		@Param('folderId') folderId: string,
 		@Param('objectSchemaIdentifier') objectSchemaIdentifier: string,
-		@SessionUser() user: SessionUserEntity
+		@SessionUser() user: SessionUserEntity,
+		@Req() request: Request
 	): Promise<{ status: string }> {
 		const collection = await this.foldersService.findFolderById(folderId, referer, ip);
 		if (collection.userProfileId !== user?.getId()) {
 			throw new ForbiddenException('You can only delete objects from your own folders');
 		}
-		const ieObjectId =
-			await this.ieObjectsService.getObjectIdBySchemaIdentifierCached(objectSchemaIdentifier);
+
+		const ieObjectId = await this.ieObjectsService.getIeObjectIdFromObjectSchemaIdentifier(
+			objectSchemaIdentifier,
+			request
+		);
+
 		const affectedRows = await this.foldersService.removeObjectFromFolder(
 			folderId,
 			ieObjectId,
@@ -306,7 +311,8 @@ export class FoldersController {
 		@Param('oldFolderId') oldFolderId: string,
 		@Param('objectSchemaIdentifier') objectSchemaIdentifier: string,
 		@Query('newFolderId') newFolderId: string,
-		@SessionUser() user: SessionUserEntity
+		@SessionUser() user: SessionUserEntity,
+		@Req() request: Request
 	): Promise<Partial<IeObject> & { folderEntryCreatedAt: string }> {
 		// Check user is owner of both folders
 		const [oldFolder, newFolder] = await Promise.all([
@@ -320,8 +326,11 @@ export class FoldersController {
 			throw new ForbiddenException('You can only move objects to your own folders');
 		}
 
-		const ieObjectId =
-			await this.ieObjectsService.getObjectIdBySchemaIdentifierCached(objectSchemaIdentifier);
+		const ieObjectId = await this.ieObjectsService.getIeObjectIdFromObjectSchemaIdentifier(
+			objectSchemaIdentifier,
+			request
+		);
+
 		const folderObject = await this.foldersService.addObjectToFolder(
 			newFolderId,
 			ieObjectId,
@@ -434,6 +443,19 @@ export class FoldersController {
 			await promiseUtils.mapLimit(folderObjects?.items, 20, async (item) => {
 				try {
 					const ieObjectId = item.iri;
+					if (!ieObjectId) {
+						const error = new CustomError(
+							'Failed to add object to accepted shared folder, since the iri is missing',
+							null,
+							{
+								folderId,
+								profileId: user?.getId(),
+								item,
+							}
+						);
+						console.error(error);
+						throw error;
+					}
 					await this.foldersService.addObjectToFolder(createdFolder.id, ieObjectId, referer, ip);
 				} catch (err) {
 					console.error(

--- a/src/modules/folders/services/folders.service.ts
+++ b/src/modules/folders/services/folders.service.ts
@@ -2,6 +2,7 @@ import { DataService } from '@meemoo/admin-core-api';
 import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { type IPagination, Pagination } from '@studiohyperdrive/pagination';
 import { format } from 'date-fns';
+import type { Request } from 'express';
 import { isEmpty, maxBy } from 'lodash';
 
 import type {
@@ -48,6 +49,7 @@ import type { IeObject, IeObjectSector, IeObjectType } from '~modules/ie-objects
 
 import { IeObjectsService } from '~modules/ie-objects/services/ie-objects.service';
 
+import { CustomError } from '@meemoo/admin-core-api/dist/src/modules/shared/helpers/error';
 import { VisitsService } from '~modules/visits/services/visits.service';
 import { PaginationHelper } from '~shared/helpers/pagination';
 
@@ -371,7 +373,10 @@ export class FoldersService {
 		const objectInfo = await this.ieObjectsService.findByIeObjectId(ieObjectId, false, referer, ip);
 
 		if (!objectInfo) {
-			throw new NotFoundException(`Object with id ${ieObjectId} was not found`);
+			throw new CustomError(`Object with id ${ieObjectId} was not found`, null, {
+				folderId,
+				ieObjectId,
+			});
 		}
 
 		const response = await this.dataService.execute<

--- a/src/modules/ie-objects/controllers/ie-objects.controller.spec.ts
+++ b/src/modules/ie-objects/controllers/ie-objects.controller.spec.ts
@@ -9,7 +9,7 @@ import { Test, type TestingModule } from '@nestjs/testing';
 import type { IPagination } from '@studiohyperdrive/pagination';
 import type { Request, Response } from 'express';
 import { cloneDeep } from 'lodash';
-import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { type MockInstance, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
 	type IeObject,
@@ -63,7 +63,7 @@ const mockIeObjectsService: Partial<Record<keyof IeObjectsService, MockInstance>
 		objectIds: [],
 		visitorSpaceIds: [],
 	})),
-	getObjectIdBySchemaIdentifierCached: vi.fn().mockResolvedValue('mock-ie-object-id'),
+	getIeObjectIdFromObjectSchemaIdentifier: vi.fn().mockResolvedValue('mock-ie-object-id'),
 	getRepresentationAndFileInIeObject: vi.fn(),
 };
 
@@ -372,7 +372,8 @@ describe('IeObjectsController', () => {
 				mockSessionUser,
 				'false',
 				undefined,
-				undefined
+				undefined,
+				{ path: '', params: {} } as unknown as Request
 			);
 
 			expect(ieObjects[0]).toBeDefined();
@@ -392,7 +393,8 @@ describe('IeObjectsController', () => {
 					mockSessionUser,
 					'false',
 					undefined,
-					undefined
+					undefined,
+					{ path: '', params: {} } as unknown as Request
 				);
 				fail('Expected an error to be thrown if the object does not exist');
 			} catch (err) {
@@ -413,7 +415,8 @@ describe('IeObjectsController', () => {
 					mockSessionUser,
 					'false',
 					undefined,
-					undefined
+					undefined,
+					{ path: '', params: {} } as unknown as Request
 				);
 				fail('Expected an error to be thrown if the object does not exist');
 			} catch (err) {
@@ -435,7 +438,8 @@ describe('IeObjectsController', () => {
 				mockSessionUser,
 				'true',
 				'referer',
-				'127.0.0.1'
+				'127.0.0.1',
+				{ path: '', params: {} } as unknown as Request
 			);
 
 			expect(ieObjects[0].schemaIdentifier).toEqual(mockIeObject1.schemaIdentifier);
@@ -458,7 +462,8 @@ describe('IeObjectsController', () => {
 				mockSessionUser,
 				'true',
 				'referer',
-				'127.0.0.1'
+				'127.0.0.1',
+				{ path: '', params: {} } as unknown as Request
 			);
 
 			expect(ieObjects[0].thumbnailUrl).toBeUndefined();
@@ -479,7 +484,8 @@ describe('IeObjectsController', () => {
 				mockSessionUser,
 				'true',
 				'referer',
-				'127.0.0.1'
+				'127.0.0.1',
+				{ path: '', params: {} } as unknown as Request
 			);
 
 			expect(ieObjects[0].schemaIdentifier).toEqual(mockResponse.schemaIdentifier);
@@ -496,7 +502,10 @@ describe('IeObjectsController', () => {
 			};
 			mockIeObjectsService.findByIeObjectId.mockResolvedValueOnce(mockResponse);
 
-			const result = await ieObjectsController.getIeObjectSeoById('referer', '127.0.0.1', '1');
+			const result = await ieObjectsController.getIeObjectSeoById('referer', '127.0.0.1', '1', {
+				path: '',
+				params: {},
+			} as unknown as Request);
 
 			expect(result).toEqual({
 				name: mockIeObject1.name,
@@ -513,7 +522,10 @@ describe('IeObjectsController', () => {
 			};
 			mockIeObjectsService.findByIeObjectId.mockResolvedValueOnce(mockResponse);
 
-			const result = await ieObjectsController.getIeObjectSeoById('referer', '127.0.0.1', '1');
+			const result = await ieObjectsController.getIeObjectSeoById('referer', '127.0.0.1', '1', {
+				path: '',
+				params: {},
+			} as unknown as Request);
 
 			expect(result).toEqual({
 				name: mockIeObject1.name,
@@ -530,7 +542,10 @@ describe('IeObjectsController', () => {
 			};
 			mockIeObjectsService.findByIeObjectId.mockResolvedValue(mockResponse);
 
-			const result = await ieObjectsController.getIeObjectSeoById('referer', '127.0.0.1', '1');
+			const result = await ieObjectsController.getIeObjectSeoById('referer', '127.0.0.1', '1', {
+				path: '',
+				params: {},
+			} as unknown as Request);
 
 			expect(result).toEqual({
 				name: mockIeObject1.name,
@@ -547,7 +562,10 @@ describe('IeObjectsController', () => {
 			};
 			mockIeObjectsService.findByIeObjectId.mockResolvedValueOnce(mockResponse);
 
-			const result = await ieObjectsController.getIeObjectSeoById('referer', '127.0.0.1', '1');
+			const result = await ieObjectsController.getIeObjectSeoById('referer', '127.0.0.1', '1', {
+				path: '',
+				params: {},
+			} as unknown as Request);
 
 			expect(result).toEqual({
 				name: null,

--- a/src/modules/ie-objects/controllers/ie-objects.controller.ts
+++ b/src/modules/ie-objects/controllers/ie-objects.controller.ts
@@ -54,8 +54,8 @@ import {
 	IeObjectForAccessCheck,
 	IeObjectLicense,
 	type IeObjectSeo,
-	type IeObjectsWithAggregations,
 	IeObjectType,
+	type IeObjectsWithAggregations,
 	type RelatedIeObject,
 	type RelatedIeObjects,
 } from '../ie-objects.types';
@@ -239,7 +239,8 @@ export class IeObjectsController {
 			user,
 			'false',
 			referer,
-			ip
+			ip,
+			{ path: 'getAccessibleObjectForTicket', params: { schemaIdentifier } } as unknown as Request
 		);
 		const accessibleObject = accessibleObjects[0];
 
@@ -334,10 +335,14 @@ export class IeObjectsController {
 	public async getIeObjectSeoById(
 		@Referer() referer: string,
 		@Ip() ip: string,
-		@Param('schemaIdentifier') schemaIdentifier: string
+		@Param('schemaIdentifier') schemaIdentifier: string,
+		@Req() request: Request
 	): Promise<IeObjectSeo> {
-		const ieObjectId =
-			await this.ieObjectsService.getObjectIdBySchemaIdentifierCached(schemaIdentifier);
+		const ieObjectId = await this.ieObjectsService.getIeObjectIdFromObjectSchemaIdentifier(
+			schemaIdentifier,
+			request
+		);
+
 		const ieObject = await this.ieObjectsService.findByIeObjectId(ieObjectId, true, referer, ip);
 
 		const hasPublicAccess = ieObject?.licenses.some((license: IeObjectLicense) =>
@@ -899,6 +904,7 @@ export class IeObjectsController {
 	 * @param referer site making the request. eg: https://qas-v3.hetarchief.be
 	 * @param ip Ip of the client making the request. eg: 172.17.45.216
 	 * @param user Currently logged-in user
+	 * @param request
 	 */
 	@Get('thumbnails')
 	@ApiOperation({ summary: 'Get ie-object thumbnails by schema identifiers' })
@@ -919,7 +925,8 @@ export class IeObjectsController {
 		@Query('ids') schemaIdentifiers: string[],
 		@Referer() referer: string | null,
 		@Ip() ip: string,
-		@SessionUser() user: SessionUserEntity
+		@SessionUser() user: SessionUserEntity,
+		@Req() request: Request
 	): Promise<
 		{
 			schemaIdentifier: string;
@@ -956,8 +963,10 @@ export class IeObjectsController {
 					return null;
 				}
 
-				const ieObjectId =
-					await this.ieObjectsService.getObjectIdBySchemaIdentifierCached(schemaIdentifier);
+				const ieObjectId = await this.ieObjectsService.getIeObjectIdFromObjectSchemaIdentifier(
+					schemaIdentifier,
+					request
+				);
 				const ieObject = await this.ieObjectsService.findThumbnailByIeObjectId(ieObjectId);
 
 				// Censor the object based on the licenses and sector
@@ -1026,6 +1035,7 @@ export class IeObjectsController {
 	 * @param resolveThumbnailUrl
 	 * @param referer site making the request. eg: https://qas-v3.hetarchief.be
 	 * @param ip Ip of the client making the request. eg: 172.17.45.216
+	 * @param request
 	 */
 
 	@Get()
@@ -1060,7 +1070,8 @@ export class IeObjectsController {
 		@SessionUser() user: SessionUserEntity,
 		@Query('resolveThumbnailUrl') resolveThumbnailUrl: 'true' | 'false',
 		@Referer() referer: string | null,
-		@Ip() ip: string
+		@Ip() ip: string,
+		@Req() request: Request
 	): Promise<(Partial<IeObject> | null)[]> {
 		try {
 			let ieObjectIdsResolved: string[];
@@ -1078,8 +1089,9 @@ export class IeObjectsController {
 						schemaIdentifiersResolved,
 						12,
 						async (schemaIdentifier: string): Promise<string | null> => {
-							return await this.ieObjectsService.getObjectIdBySchemaIdentifierCached(
-								schemaIdentifier
+							return await this.ieObjectsService.getIeObjectIdFromObjectSchemaIdentifier(
+								schemaIdentifier,
+								request
 							);
 						}
 					);

--- a/src/modules/ie-objects/services/ie-objects.service.ts
+++ b/src/modules/ie-objects/services/ie-objects.service.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs/promises';
 import { retry } from 'async';
+import { Request } from 'express';
 
 import { DataService, PlayerTicketService } from '@meemoo/admin-core-api';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
@@ -42,10 +43,10 @@ import {
 	type IeObjectPages,
 	type IeObjectRepresentation,
 	type IeObjectSector,
+	IeObjectType,
 	type IeObjectsSitemap,
 	type IeObjectsVisitorSpaceInfo,
 	type IeObjectsWithAggregations,
-	IeObjectType,
 	type IsPartOfKey,
 	type Mention,
 	type RelatedIeObject,
@@ -98,18 +99,18 @@ import {
 } from '~modules/ie-objects/elasticsearch/elasticsearch.consts';
 import { AND } from '~modules/ie-objects/elasticsearch/queryBuilder.helpers';
 import {
-	convertStringToSearchTerms,
 	type SearchTermParseResult,
+	convertStringToSearchTerms,
 } from '~modules/ie-objects/helpers/convert-string-to-search-terms';
 import {
 	AUTOCOMPLETE_FIELD_TO_ES_FIELD_NAME,
 	IE_OBJECT_AV_TYPES,
 } from '~modules/ie-objects/ie-objects.conts';
 import {
+	CACHE_KEY_PREFIX_IE_OBJECTS_SEARCH,
 	CACHE_KEY_PREFIX_IE_OBJECT_DETAIL,
 	CACHE_KEY_PREFIX_IE_OBJECT_PID_TO_ID,
 	CACHE_KEY_PREFIX_IE_OBJECT_THUMBNAIL,
-	CACHE_KEY_PREFIX_IE_OBJECTS_SEARCH,
 } from '~modules/ie-objects/services/ie-objects.service.consts';
 import {
 	type DbFile,
@@ -419,7 +420,10 @@ export class IeObjectsService {
 				visitorSpaceInfo: visitorSpaceAccessInfo,
 			}
 		);
-		const ieObjectId = await this.getObjectIdBySchemaIdentifierCached(schemaIdentifier);
+		const ieObjectId = await this.getIeObjectIdFromObjectSchemaIdentifier(schemaIdentifier, {
+			path: 'getSimilar',
+			params: { schemaIdentifier, ieObjectSimilarQueryDto, limit },
+		} as unknown as Request);
 		const childrenIris = await this.getIeObjectChildrenIris(ieObjectId);
 
 		const esQueryObject = {
@@ -1734,7 +1738,7 @@ export class IeObjectsService {
 		}
 	}
 
-	public async getObjectIdBySchemaIdentifierCached(
+	private async getObjectIdBySchemaIdentifierCached(
 		schemaIdentifier: string
 	): Promise<string | null> {
 		try {
@@ -1775,5 +1779,47 @@ export class IeObjectsService {
 			});
 		});
 		return [requestedFile, requestedRepresentation];
+	}
+
+	/**
+	 * Gets the ieObjectId from the objectSchemaIdentifier with extra error checking
+	 * objectSchemaIdentifier: pid. eg: qs4t6h385n
+	 * ieObjectId: primary key of the intellectual entity in the database. eg: https://data-qas.hetarchief.be/id/entity/qs4t6h385n
+	 * @param objectSchemaIdentifier
+	 * @param request
+	 */
+	async getIeObjectIdFromObjectSchemaIdentifier(
+		objectSchemaIdentifier: string | null | undefined,
+		request: Request | null
+	): Promise<string> {
+		if (!objectSchemaIdentifier) {
+			const error = new CustomError(
+				'This endpoint requires a objectSchemaIdentifier query param',
+				null,
+				{
+					path: '/folders/:folderId/objects/:objectSchemaIdentifier',
+					requestPath: request?.path,
+					params: request?.params,
+					objectSchemaIdentifier,
+				}
+			);
+			console.error(error);
+			throw error;
+		}
+
+		const ieObjectId = await this.getObjectIdBySchemaIdentifierCached(objectSchemaIdentifier);
+
+		if (!ieObjectId) {
+			const error = new CustomError('No object id was found for objectSchemaIdentifier', null, {
+				path: '/folders/:folderId/objects/:objectSchemaIdentifier',
+				requestPath: request?.path,
+				params: request?.params,
+				objectSchemaIdentifier,
+			});
+			console.error(error);
+			throw error;
+		}
+
+		return ieObjectId;
 	}
 }

--- a/src/modules/newspapers/controllers/newspapers.controller.ts
+++ b/src/modules/newspapers/controllers/newspapers.controller.ts
@@ -74,7 +74,8 @@ export class NewspapersController {
 			// No need to add player tickets to the thumbnail urls
 			'false',
 			null,
-			null
+			null,
+			request
 		);
 		const limitedObjectMetadata = limitedObjectMetadatas[0];
 
@@ -246,7 +247,8 @@ export class NewspapersController {
 			user,
 			'false',
 			undefined,
-			undefined
+			undefined,
+			request
 		);
 		const limitedObjectMetadata = limitedObjectMetadatas[0];
 


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-3756

Na de grote outage van 23 juni hebben we in de logs deze errors gezien:
```
[Nest] 1 - 06/24/2026, 8:18:16 AM ERROR [DataService] InternalServerErrorException: { message: 'Failed to get data from database',
innerException:
{ InternalServerErrorException: Internal Server Error Exception
at DataService.execute (/app/node_modules/@meemoo/admin-core-api/dist/src/modules/data/services/data.service.js:73:23)
at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
at async /app/dist/src/modules/ie-objects/services/ie-objects.service.js:291:30
at async Promise.all (index 15)
response:
{ errors:
[ { message: 'null value found for non-nullable type: "String!"',
extensions: { path: '$', code: 'validation-failed' } } ] },
status: 500,
options: {} },
additionalInfo:
{ requestUrl: undefined,
query: 'getSchemaKeywords',
variables: { ieObjectId: null } },
stack:
'InternalServerErrorException: Internal Server Error Exception\n at DataService.execute (/app/node_modules/@meemoo/admin-core-api/dist/src/modules/data/services/data.service.js:73:23)\n at process.processTicksAndRejections (node:internal/process/task_queues:104:5)\n at async /app/dist/src/modules/ie-objects/services/ie-objects.service.js:291:30\n at async Promise.all (index 15)' } +0ms
```

Deze pr voegt wat extra checks to om te zorgen dat we nooit queries uitvoeren voor getIeObject met ieObjectOId === null