### PR TITLE
fix(mediahaven): improve export jobs error logging

### DIFF
--- a/src/modules/mediahaven-jobs-watcher/services/mediahaven-jobs-watcher.service.ts
+++ b/src/modules/mediahaven-jobs-watcher/services/mediahaven-jobs-watcher.service.ts
@@ -408,7 +408,7 @@ export class MediahavenJobsWatcherService {
 
 	private async getMediaHavenExportJobRequestBody(
 		materialRequest: MaterialRequestForDownload
-	): Promise<CreateMamJobRequestBody | null> {
+	): Promise<CreateMamJobRequestBody> {
 		let records: CreateMamJobRequestBody['Records'];
 
 		try {
@@ -471,7 +471,13 @@ export class MediahavenJobsWatcherService {
 				Reason: `Export for hetarchief.be material request ${materialRequest.id}`,
 				Tag: this.configService.get('MEDIAHAVEN_EXPORT_JOBS_TAG'),
 			};
-		} catch (err) {}
+		} catch (err) {
+			const error = new CustomError('Failed to create mediahaven export job', err, {
+				materialRequestId: materialRequest.id,
+			});
+			console.error(error);
+			throw error;
+		}
 	}
 
 	/**
@@ -502,7 +508,7 @@ export class MediahavenJobsWatcherService {
 				try {
 					responseBody = await response.text();
 				} catch (err) {
-					// ignore error, we don't need the response body perse
+					// ignore error, we don't need the response body necessarily
 				}
 				throw new CustomError(
 					'Error received when creating mediahaven export job',
@@ -588,20 +594,25 @@ export class MediahavenJobsWatcherService {
 			jobs.map((job) => job.ExportJobId)
 		);
 
-		return await mapLimit(
-			jobs,
-			10,
-			async (
-				job
-			): Promise<{ requestInfo: CreateMamJobRequestBody; exportJobStatus: MediahavenJobInfo }> => {
+		const getJobInfo = async (
+			job: MediahavenJobInfo
+		): Promise<{
+			requestInfo: CreateMamJobRequestBody;
+			exportJobStatus: MediahavenJobInfo;
+		}> => {
+			try {
 				const materialRequest = materialRequests.find((mr) => mr.downloadJobId === job.ExportJobId);
 				if (!materialRequest) {
 					return { requestInfo: null, exportJobStatus: job };
 				}
 				const requestInfo = await this.getMediaHavenExportJobRequestBody(materialRequest);
 				return { requestInfo, exportJobStatus: job };
+			} catch (err) {
+				return null;
 			}
-		);
+		};
+		const jobInfos = await mapLimit(jobs, 10, getJobInfo);
+		return compact(jobInfos);
 	}
 
 	/**


### PR DESCRIPTION
since we're seeing errors like this on prd:
```
CustomError {
  identifier: '59b0ce12-ad3b-4f1e-91c6-ae38e8ce593d',
  name: 'Error',
  statusCode: 500,
  timestamp: '2026-07-07T13:35:16.446Z',
  message: 'Failed to create mediahaven export job',
  innerException: CustomError {
  identifier: 'adf2ea71-0ca7-4a83-bcd8-adab86a9caca',
  name: 'Error',
  statusCode: 500,
  timestamp: '2026-07-07T13:35:16.445Z',
  message: 'Error received when creating mediahaven export job',
  innerException: '',
  additionalInfo: {
    status: 400,
    statusText: '',
    responseBody: '{"Status":400,"Message":"Required request body is missing","Code":"EBADREQ"}'
  }
}
```