### PR TITLE
Adds random order to IE objects search

### DIFF
--- a/src/modules/ie-objects/elasticsearch/elasticsearch.consts.ts
+++ b/src/modules/ie-objects/elasticsearch/elasticsearch.consts.ts
@@ -107,6 +107,7 @@ export enum OrderProperty {
 	CREATED = 'created',
 	ARCHIVED = 'archived',
 	NAME = 'name',
+	RANDOM = 'random',
 }
 
 export enum QueryType {
@@ -339,6 +340,7 @@ export const ORDER_MAPPINGS: { [prop in OrderProperty]: string } = {
 	[OrderProperty.CREATED]: 'schema_date_created',
 	[OrderProperty.ARCHIVED]: 'dcterms_available',
 	[OrderProperty.NAME]: 'schema_name.keyword',
+	[OrderProperty.RANDOM]: '_score',
 };
 
 export const MULTI_MATCH_FIELDS: Array<IeObjectsSearchFilterField> = [

--- a/src/modules/ie-objects/elasticsearch/queryBuilder.ts
+++ b/src/modules/ie-objects/elasticsearch/queryBuilder.ts
@@ -53,6 +53,7 @@ import {
 	VALUE_OPERATORS,
 } from './elasticsearch.consts';
 
+import { randomInt } from 'node:crypto';
 import { AND, OR, applyFilter } from '~modules/ie-objects/elasticsearch/queryBuilder.helpers';
 import { GroupId, GroupName } from '~modules/users/types';
 import { PaginationHelper } from '~shared/helpers/pagination';
@@ -223,7 +224,7 @@ export class QueryBuilder {
 						function_score: {
 							query: boolQuery,
 							random_score: {
-								seed: 42,
+								seed: randomInt(0, 20), // balance between new items and being able to cache these responses
 								field: '_seq_no',
 							},
 						},

--- a/src/modules/ie-objects/elasticsearch/queryBuilder.ts
+++ b/src/modules/ie-objects/elasticsearch/queryBuilder.ts
@@ -32,17 +32,17 @@ import {
 	IeObjectsSearchFilterField,
 	MAX_COUNT_SEARCH_RESULTS,
 	MAX_NUMBER_SEARCH_RESULTS,
-	MetadataAccessType,
 	MULTI_MATCH_FIELDS,
 	MULTI_MATCH_QUERY_MAPPING,
+	MetadataAccessType,
 	NEEDS_AGG_SUFFIX,
 	NEEDS_FILTER_SUFFIX,
 	NUMBER_OF_FILTER_OPTIONS_DEFAULT,
 	NUMBER_OF_OPTIONS_PER_AGGREGATE,
-	OccurenceType,
 	OCCURRENCE_TYPE,
-	Operator,
 	ORDER_MAPPINGS,
+	OccurenceType,
+	Operator,
 	OrderProperty,
 	type QueryBuilderInputInfo,
 	QueryType,
@@ -53,7 +53,7 @@ import {
 	VALUE_OPERATORS,
 } from './elasticsearch.consts';
 
-import { AND, applyFilter, OR } from '~modules/ie-objects/elasticsearch/queryBuilder.helpers';
+import { AND, OR, applyFilter } from '~modules/ie-objects/elasticsearch/queryBuilder.helpers';
 import { GroupId, GroupName } from '~modules/users/types';
 import { PaginationHelper } from '~shared/helpers/pagination';
 import type { SortDirection } from '~shared/types';
@@ -74,6 +74,7 @@ export class QueryBuilder {
 	 * @return elastic search query
 	 */
 	public static build(searchRequest: IeObjectsQueryDto, inputInfo: QueryBuilderInputInfo): any {
+		const isRandomOrder = searchRequest.orderProp === OrderProperty.RANDOM;
 		// Check if all filter fields are known
 		(searchRequest?.filters || []).find((searchFilter) => {
 			if (!Object.values(IeObjectsSearchFilterField).includes(searchFilter.field)) {
@@ -166,11 +167,10 @@ export class QueryBuilder {
 			// Specify the aggs objects with optional search terms
 			const aggs = QueryBuilder.buildAggsObject(searchRequest);
 
-			// Add sorting
-			const sort = QueryBuilder.buildSortArray(
-				searchRequest.orderProp,
-				searchRequest.orderDirection
-			);
+			// Add sorting if orderProp is not random
+			const sort = isRandomOrder
+				? {}
+				: QueryBuilder.buildSortArray(searchRequest.orderProp, searchRequest.orderDirection);
 
 			/**
 			 * Assemble the complete query object:
@@ -201,22 +201,37 @@ export class QueryBuilder {
 			 * 				* AND
 			 * 				* organisation with correct sector
 			 */
-			return {
-				query: OR([
-					// metadata limited
-					AND([queryFromMetadataLimitedFilters, ...licensesFilterPublicLimited]),
-					// metadata all
-					AND([
-						queryFromMetadataAllFilters,
-						OR([
-							...licensesFilterPublicAll,
-							...licensesFilterVisitorSpaceFullAccess,
-							...licensesFilterVisitorSpaceFolderAccess,
-							...licensesFilterIntraCpFullAccess,
-							...licensesFilterKeyUsers,
-						]),
+			const boolQuery = OR([
+				// metadata limited
+				AND([queryFromMetadataLimitedFilters, ...licensesFilterPublicLimited]),
+				// metadata all
+				AND([
+					queryFromMetadataAllFilters,
+					OR([
+						...licensesFilterPublicAll,
+						...licensesFilterVisitorSpaceFullAccess,
+						...licensesFilterVisitorSpaceFolderAccess,
+						...licensesFilterIntraCpFullAccess,
+						...licensesFilterKeyUsers,
 					]),
 				]),
+			]);
+
+			// Wrap in random order, if orderProp is random
+			const query = isRandomOrder
+				? {
+						function_score: {
+							query: boolQuery,
+							random_score: {
+								seed: 42,
+								field: '_seq_no',
+							},
+						},
+					}
+				: boolQuery;
+
+			return {
+				query,
 				size,
 				from,
 				aggs,
@@ -245,6 +260,12 @@ export class QueryBuilder {
 	 * @param orderDirection
 	 */
 	private static buildSortArray(orderProperty: OrderProperty, orderDirection: SortDirection) {
+		if (orderProperty === OrderProperty.RANDOM) {
+			// The random ordering is handled by wrapping the query in a function_score with a random_score,
+			// so we only need to sort by the (randomized) relevance score here.
+			return [ORDER_MAPPINGS[OrderProperty.RELEVANCE]];
+		}
+
 		const mappedOrderProperty = ORDER_MAPPINGS[orderProperty];
 		const sortArray: any[] = [];
 		if (orderProperty !== OrderProperty.RELEVANCE) {


### PR DESCRIPTION
Adds a new option to order search results for IE objects randomly.

This update:
- Introduces a `RANDOM` property to the `OrderProperty` enum.
- Modifies the Elasticsearch query to wrap the main boolean query in a `function_score` with a `random_score` function when the random order is selected.
- Ensures a degree of randomness for each request by generating a dynamic seed, balancing unique results with potential for caching.
- Adjusts the query builder to correctly apply this new ordering mechanism.

Relates to https://meemoo.atlassian.net/browse/ARC-3792